### PR TITLE
[feature](agent) Port code-review skill and AGENTS.md to branch-3.1

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: code-review
+description: Review code with Doris-specific checklists
+compatibility: opencode
+---
+
+## What I do
+
+Complete code review work to ensure code quality. Due to the length of content, you can read sections as needed based on the actual modifications being reviewed.
+
+## When to use me
+
+Use this when you need to review code, whether it is code you just completed or directly reviewing target code.
+
+## How to use me
+
+1. **Always read and respond to Part 1** (General Principles) — it applies to all code.
+2. For module-specific review, **read the `AGENTS.md` in the corresponding source directory** listed in Part 2. Those files contain non-obvious conventions and traps specific to each subsystem.
+3. Parts 3–7 cover cross-module concerns, testing, high-risk patterns, functions, and standards — refer as needed.
+
+---
+
+## Part 1: General Principles
+
+### 1.1 Core Invariants
+
+Always focus on the following core invariants during review:
+1. **Data Correctness**: Data from any committed transaction must be visible to subsequent queries and not lost; data from uncommitted transactions must not be visible
+2. **Version Consistency**: Partition visible version is the sole standard for data visibility; BE must strictly read data not exceeding this version
+3. **Delete Bitmap Consistency** (MoW tables): delete bitmap must be strictly aligned with rowset versions; sentinel marks and `TEMP_VERSION`-style placeholders must be replaced with actual versions before use
+4. **Memory Safety**: All significant memory allocations must be tracked by `MemTracker`; orphan memory is not allowed
+5. **Error Means Failure**: Invariant violations should trigger exceptions or non-OK `Status`; silent continuation is never allowed
+
+### 1.2 Review Principles
+
+- **Branch Compatibility (branch-3.1)**: Be aware that these guidelines originated from the `master` branch. If a guideline enforces a new architectural pattern, macro (e.g., `Result<T>` everywhere), or class that does not exist or is not widely adopted in `branch-3.1`, gracefully fallback to the existing paradigms in `branch-3.1`.
+- **Follow Context**: Match adjacent code's error handling, interface usage, and lock patterns unless a clearly better approach exists
+- **Reuse First**: Search for existing implementations before adding new ones; ensure good abstraction afterward. For example, in the implementation of SQL functions in BE, we prefer to use an existing base template rather than implementing everything from scratch. The same principle applies to the implementation of other features. Common parts should be abstracted as much as possible.
+- **Code Over Docs**: When this skill conflicts with actual code, defer to code and note the mismatch
+- **Performance First**: All obviously redundant operations should be optimized away, all obvious performance optimizations must be applied, and obvious anti-patterns must be eliminated.
+- **Evidence Speaks**: All issues with code itself (not memory or environment) must be clearly identified as either having problems or not. For any erroneous situation, if it cannot be confirmed locally, you must provide the specific path or logic where the error occurs. That is, if you believe that if A then B, you must specify a clear scenario where A occurs.
+- **Review Holistically**: For any new feature or modification, you must analyze its upstream and downstream code to understand the real invocation chain. Identify all implicit assumptions and constraints throughout the flow, then verify carefully that the current change works correctly within the entire end-to-end process. Also determine whether a seemingly problematic local pattern is actually safe due to strong guarantees from upstream or downstream, or whether a conventional local implementation fails to achieve optimal performance because it does not leverage additional information available from the surrounding context.
+
+### 1.3 Critical Checkpoints (Self-Review and Review Priority)
+
+The following checkpoints must be **individually confirmed with conclusions** during self-review and review. If the code is too long or too complex, you should delve into the code again as needed when analyzing specific issues, especially the entire logic chain where there are doubts:
+
+- What is the goal of the current task? Does the current code accomplish this goal? Is there a test that proves it?
+- Is this modification as small, clear, and focused as possible?
+- Does the code segment involve concurrency? If yes:
+  - Which threads introduce concurrency, what are the critical variables? What locks protect them?
+  - Are operations within locks as lightweight as possible? Are all heavy operations outside locks while maintaining concurrency safety?
+  - If multiple locks exist, is the locking order consistent? Is there deadlock risk?
+- Is there special or non-intuitive lifecycle management including static initialization order? If yes:
+  - Understand the complete lifecycle and relationships of related variables. Are there circular references? When is each released? Can all lifecycles end normally?
+  - For cross-TU static/global variables: does the initializer of one static variable depend on another static variable defined in a different translation unit? If yes, the initialization order is undefined by the C++ standard (static initialization order fiasco). Use constexpr, inline variables in the same header, or lazy initialization to fix.
+- Are configuration items added?
+  - Should the configuration allow dynamic changes, and does it actually allow them? If yes:
+    - Can affected processes detect the change promptly without restart?
+- Does it involve incompatible changes like function symbols or storage formats? If yes:
+  - Is compatibility code added? Can it correctly handle requests during rolling upgrades?
+- Are there functionally parallel code paths to the modified one? If yes:
+  - Should this modification be applied to other paths, and has it been?
+- Are there special conditional checks? If yes:
+  - Does the condition have clear comments explaining why this check is necessary, simplest, and most viable?
+  - Are there similar paths with similar issues?
+- What is the test coverage?
+  - Are end-to-end functional tests comprehensive?
+  - Are there comprehensive negative test cases from various angles?
+  - For complex features, are key functions sufficiently modular with unit tests?
+- Does the feature need increased observability? If yes:
+  - When bugs occur, are existing logs and VLOGs sufficient to investigate key issues?
+  - Are INFO logs lightweight enough?
+  - Are Metrics added for critical paths? Referencing similar features, are all necessary observability values covered?
+- Does it involve transaction and persistence-related modifications? If yes:
+  - Are all EditLog reads and writes correctly covered? Is all information requiring persistent storage persisted? Does it follow our standard approach?
+  - In transaction processing logic, can master failover at any time point be handled correctly?
+- Does it involve data writes and modifications? If yes:
+  - Are transactionality and atomicity guaranteed? Are there issues with concurrency?
+  - Would FE or BE crashes cause leaks, deadlocks, or incorrect data?
+- Are new variables added that need to be passed between FE and BE? If yes:
+  - Is variable passing modified in all paths? For example, various scattered thrift sending points like constant folding, point queries.
+- Analyze deeply from all angles (including but not limited to time complexity, anti-patterns, CPU and memory friendliness, redundant calculations, etc.) based on the code context and available information. Are there any performance issues or optimization opportunities?
+- Based on your understanding, are there any other issues with the current modification?
+
+After checking all the above items with code. Use the remaining parts of this skill as needed. The following content does not need individual responses; just check during the review process.
+
+#### 1.3.1 Concurrency and Thread Safety (Highest Priority)
+
+- [ ] **Thread context**: Does every new thread or bthread entry attach the right memory-tracking context? (See `be/src/runtime/AGENTS.md`)
+- [ ] **Lock protection**: Is shared data accessed under the correct lock and mode?
+- [ ] **Lock order**: Do nested acquisitions follow the module's documented lock order? (See storage, schema-change, cloud AGENTS.md)
+- [ ] **Atomic memory order**: `relaxed` for counters only; at least `acquire/release` for signals and lifecycle flags
+
+#### 1.3.2 Error Handling (Highest Priority)
+
+- [ ] **Status checking**: Every `Status` must be checked; silent discard is prohibited
+- [ ] **Exception propagation**: Is there a catch-and-convert boundary above every `THROW_IF_ERROR`? (See `be/src/common/AGENTS.md`)
+- [ ] **Error context**: Do error messages include table, partition, tablet, or transaction identifiers?
+- [ ] **Assertions**: `DORIS_CHECK` for invariants only, never speculative defensive checks
+
+#### 1.3.3 Memory Safety (High Priority)
+
+- [ ] **Reservation**: `try_reserve()` before large allocations, with guaranteed release on every exit path
+- [ ] **Ownership**: See `be/src/runtime/AGENTS.md` for cache-handle, shared_ptr-cycle, and factory-creator rules
+
+#### 1.3.4 Data Correctness (High Priority)
+
+- [ ] **Version consistency**: Does data reading stay at or below the visible version?
+- [ ] **MoW correctness**: See `be/src/storage/AGENTS.md` for delete-bitmap sentinel replacement, MoW enablement, and serialization rules
+- [ ] **EditLog**: Are metadata changes logged and replayed equivalently? (See `fe/.../persist/AGENTS.md`)
+
+#### 1.3.5 Observability (Medium Priority)
+
+- [ ] Are critical new paths observable with appropriate log levels and metrics?
+- [ ] Do distributed operations include enough identifiers for tracing?
+
+### 1.4 Test Coverage Principles
+
+- All kernel features **must** have tests; prioritize regression tests, add unit tests where practical
+- `.out` files must be auto-generated, never handwritten
+- Use `order_qt_` or explicit `ORDER BY` for deterministic output
+- Expected errors: `test { sql "..."; exception "..." }`
+- Drop tables before use, not after, to preserve debug state
+- Hardcode table names in simple tests instead of `def tableName`
+
+---
+
+## Part 2: Module-Specific Review Guides (AGENTS.md)
+
+Detailed module review guides live in `AGENTS.md` files in each source directory. **Read the relevant file** when reviewing module-specific code.
+
+### BE Module
+
+| Directory | Coverage |
+|-----------|----------|
+| `be/src/common/AGENTS.md` | Error handling and `compile_check` |
+| `be/src/cloud/AGENTS.md` | Cloud RPC and CloudTablet sync rules |
+| `be/src/runtime/AGENTS.md` | MemTracker, cache lifecycle, SIOF, workload-group memory tracking |
+| `be/src/core/AGENTS.md` | COW columns, type metadata, serialization compatibility |
+| `be/src/exec/AGENTS.md` | Pipeline execution, dependency concurrency, spill and memory pressure |
+| `be/src/storage/AGENTS.md` | Tablet locks, rowset lifecycle, MoW delete bitmap, segment writing |
+| `be/src/storage/index/inverted/AGENTS.md` | Inverted-index lifetime, CLucene boundary, three-valued bitmap |
+| `be/src/storage/schema_change/AGENTS.md` | Schema-change strategy, lock order, MoW catch-up flow |
+| `be/src/io/AGENTS.md` | Filesystem async path and remote reader caching |
+
+### FE Module
+
+| Directory | Coverage |
+|-----------|----------|
+| `fe/fe-core/AGENTS.md` | FE locking, exception model, visible-version semantics |
+| `fe/fe-core/src/main/java/org/apache/doris/persist/AGENTS.md` | EditLog write/replay path and transaction persistence modes |
+| `fe/fe-core/src/main/java/org/apache/doris/nereids/AGENTS.md` | Rule placement, mark-join constraints, property derivation |
+| `fe/fe-core/src/main/java/org/apache/doris/transaction/AGENTS.md` | Transaction lifecycle, publish semantics, cloud manager usage |
+| `fe/fe-core/src/main/java/org/apache/doris/datasource/AGENTS.md` | External catalog initialization and reset hazards |
+| `fe/fe-core/src/main/java/org/apache/doris/backup/AGENTS.md` | Backup/restore log timing and replay ordering |
+
+### Cloud Module
+
+| Directory | Coverage |
+|-----------|----------|
+| `cloud/src/meta-store/AGENTS.md` | TxnKv, key encoding, versioned values, versionstamp helpers |
+| `cloud/src/meta-service/AGENTS.md` | Cloud transaction commit paths, RPC retry contract, Cloud MoW contract |
+| `cloud/src/recycler/AGENTS.md` | Recycler safety, two-phase delete, packed-file ordering |
+
+---
+
+## Part 3: Cross-Module Concerns
+
+### 3.1 FE-BE Protocol Compatibility
+
+- [ ] Do new `TPlanNodeType` values have matching BE handling?
+- [ ] Are all FE-to-BE send paths updated when new transmitted variables are added?
+- [ ] Is mixed-version compatibility preserved for serialization or function metadata changes?
+
+### 3.2 Cloud Mode vs Shared-Nothing Mode
+
+- [ ] Does the change handle both cloud and non-cloud paths where both exist?
+- [ ] In Cloud mode, is centrally managed partition version still the visibility source of truth?
+- [ ] Are prepare/commit rowset protocols respected for Cloud writes?
+
+### 3.3 Merge-on-Write Unique Key Tables
+
+- [ ] Does the write path probe or deduplicate against the correct rowset set?
+- [ ] Is publish-side delete bitmap work correctly serialized?
+- [ ] Is query-side delete bitmap usage version-aligned?
+- [ ] Do compaction and schema-change paths preserve MoW-specific correctness steps?
+
+### 3.4 Performance
+
+- [ ] Are hot paths free of redundant copies, repeated scans, or avoidable allocations?
+- [ ] Do cloud metadata loops avoid pathological retry or scan behavior?
+
+---
+
+## Part 4: Testing Review Guide
+
+### 4.1 Regression Tests
+
+- [ ] `order_qt_` or explicit `ORDER BY` used?
+- [ ] Expected errors use `test { sql ...; exception ... }`?
+- [ ] Tables dropped before use, not after?
+- [ ] Table names hardcoded, not `def tableName`?
+- [ ] `.out` files generated, not handwritten?
+
+### 4.2 BE Unit Tests
+
+- [ ] `TEST` / `TEST_F` used appropriately, independent of execution order?
+- [ ] Memory or resource leaks covered where relevant?
+
+### 4.3 FE Unit Tests
+
+- [ ] JUnit 5 used consistently with descriptive test names?
+- [ ] Concurrency tests use latches or barriers, not timing guesses?
+
+---
+
+## Part 5: Known High-Risk Patterns Quick Reference
+
+These are cross-module patterns that cause silent or hard-to-diagnose failures. Module-specific traps are in the corresponding `AGENTS.md` files.
+
+| Pattern | Risk | Why it's dangerous |
+|--------|------|-------------|
+| Ignored `Status` | Critical | Silent failure propagation; invariant violations go undetected |
+| `THROW_IF_ERROR` in `Defer` or destructors | Critical | Terminates during stack unwinding |
+| `THROW_IF_ERROR` without catch-and-convert boundary | High | Doris exception escapes its intended scope |
+| Cross-TU static initializer dependency | High | Initialization order undefined; crashes or wrong values at startup |
+
+---
+
+## Part 6: Function System Review Guide
+
+### 6.1 FE-BE Consistency
+
+- [ ] FE and BE compute return types independently — do they agree?
+- [ ] Function names lowercase and consistent on both sides?
+- [ ] Variadic lookup depends on argument family names — do FE families match BE registration?
+- [ ] Aliases registered on both FE and BE?
+- [ ] Aggregate intermediate types match (critical for shuffle serialization)?
+
+### 6.2 Null Handling
+
+- [ ] If `use_default_implementation_for_nulls()` is disabled, is the null map fully handled manually?
+- [ ] Do FE nullable semantics match BE implementation?
+- [ ] Is `need_replace_null_data_to_default()` set correctly for garbage-payload null positions?
+- [ ] Is nested `ColumnConst(ColumnNullable(...))` handled when default null handling is disabled?
+
+### 6.3 BE Registration
+
+- [ ] `IFunction` subclasses carry no member state?
+- [ ] Order-sensitive combinators like `_foreach` placed correctly in registration?
+- [ ] Aggregate Nullable/NotNullable tags match semantic result type?
+- [ ] `ColumnString` offset maintenance exact (off-by-one corrupts later rows silently)?
+
+---
+
+## Part 7: Development Standards Supplement
+
+### 7.1 Configuration
+
+- [ ] New `config::xxx` has comments, defaults, and standard naming?
+- [ ] Dynamic configs use the mutable form and are observed without restart?
+- [ ] Cloud-visible behavior changes: does the meta-service config need updating too?
+
+### 7.2 Metrics
+
+- [ ] New metric names follow existing module naming patterns?
+
+### 7.3 bthread Safety
+
+- [ ] No long blocking under `std::mutex` on bthread paths?
+- [ ] `bthread_usleep` used instead of thread-level sleep in coroutine code?
+
+### 7.4 Error Messages and Comments
+
+- [ ] User-visible errors include identifiers needed for debugging?
+- [ ] Lock-protected members and non-obvious TODOs have precise local comments?
+
+## Finally
+
+Item-by-item responses are required only for Part 1.3. Parts 2–7 are supporting material for finding bugs, stale assumptions, and missing coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# AGENTS.md — Apache Doris
+
+This is the codebase for Apache Doris, an MPP OLAP database. It primarily consists of the Backend module BE (be/, execution and storage engine), the Frontend module FE (fe/, optimizer and transaction core), and the Cloud module (cloud/, storage-compute separation). Your basic development workflow is: modify code, build using standard procedures, add and run tests, and submit relevant changes.
+
+## When running in a WORKTREE directory
+
+To ensure smooth test execution without interference between worktrees, the first thing to do upon entering a worktree directory is to check if `.worktree_initialized` exists. If not, execute `hooks/setup_worktree.sh`, setting `$ROOT_WORKSPACE_PATH` to the base directory (typically `${DORIS_REPO}`) beforehand. After successful execution, verify that `.worktree_initialized` has been touched and that `thirdparty/installed` dependencies exist correctly. Also check if submodules have been properly initialized; if not, do so manually.
+
+When working in worktree mode, all operations must be confined to the current worktree directory. Do not enter `${DORIS_REPO}` or use any resources there. Compilation and execution must be done within the current worktree directory. The compiled Doris cluster must use random ports not used by other worktrees (modify BE and FE conf before compilation, using a uniform offset of `${DORIS_PORT_OFFSET_RANGE}` from default ports without conflicting with other worktrees' ports). Run from the `output` directory within the worktree. To run regression tests, modify `regression-test/conf/regression-conf.groovy` and set the port numbers in jdbcUrl and other configuration items to your new ports so the corresponding worktree cluster can be used for regression testing.
+
+## Coding Standards
+
+> **Note for branch-3.1**: Since these standards were ported from the `master` branch, some cutting-edge features, error-handling macros, or architectural patterns might not be fully present in `branch-3.1`. When reviewing or writing code, **always prioritize matching the existing conventions in `branch-3.1`** over strictly forcing `master`'s new paradigms (e.g., if the old Planner is still used here, or if `Status` is preferred over `Result<T>` in certain modules).
+
+Assert correctness only—never use defensive programming with `if` or similar constructs. Any `if` check for errors must have a clearly known inevitable failure path (not speculation). If no such scenario is found, strictly avoid using `if(valid)` checks. However, you may use the `DORIS_CHECK` macro for precondition assertions (If inside performance-sensitive areas like loops, it can only be `DCHECK`). For example, if logically A=true should always imply B=true, then strictly avoid `if(A&&B)` and instead use `if(A){DORIS_CHECK(B);...}`. In short, the principle is: upon discovering errors or unexpected situations, report errors or crash—never allow the process to continue.
+
+When adding code, strictly follow existing similar code in similar contexts, including interface usage, error handling, etc., maintaining consistency. When adding any code, first try to reference existing functionality. Second, you must examine the relevant context paragraphs to fully understand the logic.
+
+After adding code, you must first conduct self-review and refactoring attempts to ensure good abstraction and reuse as much as possible.
+
+## Code Review
+
+When conducting code review (including self-review and review tasks), it is necessary to complete the key checkpoints according to our `code-review` skill and provide conclusions for each key checkpoint (if applicable) as part of the final written description. Other content does not require individual responses; just check them during the review process.
+
+## Build and Run Standards
+
+Always use only the `build.sh` script with its correct parameters to build Doris BE and FE. When building, use `-j${DORIS_PARALLELISM}` parallelism. For example, the simplest BE+FE build command is `./build.sh --be --fe -j${DORIS_PARALLELISM}`.
+Build type can be set via `BUILD_TYPE` in `custom_env.sh`, but only set it to `RELEASE` when explicitly required for performance testing; otherwise, keep it as `ASAN`.
+You may modify BE and FE ports and network settings in `conf/` before compilation to ensure correctness and avoid conflicts.
+Build artifacts are in the current directory's `output/`. If starting the service, ensure all process artifacts have their conf set with appropriate non-conflicting ports and `priority_networks = 10.16.10.3/24`. Use `--daemon` when starting. Cluster startup is slow; wait at least 30s for success. If still not ready after waiting, continue waiting. If not ready after a long time, check BE and FE logs to investigate.
+For first-time cluster startup, you may need to manually add the backend.
+
+## Testing Standards
+
+All kernel features must have corresponding tests. Prioritize adding regression tests under `regression-test/`, while also having BE unit tests (`be/test/`) and FE unit tests (`fe/fe-core/src/test/`) where possible. Interface usage in test cases must first reference similar cases.
+
+You must use the preset scripts in the codebase with their correct parameters to run tests (`run-regression-test.sh`, `run-be-ut.sh`, `run-fe-ut.sh`). Regression test result files must not be handwritten; they must be auto-generated via test scripts. When running regression tests, if using `-s` to specify a case, also try to use `-d` to specify the parent directory for faster execution. For example, for cases under `nereids_p0`, you can use `-d nereids_p0 -s xxx`, where `xxx` is the name from `suite("xxx")` in the groovy file.
+
+BE-UT compilation must use at most `${DORIS_PARALLELISM}` parallelism also.
+
+Key utility functions in BE code, as well as the core logic (functions) of complete features, must have corresponding unit tests. If it's inconvenient to add unit tests, the module design and function decomposition should be reviewed again to ensure high cohesion and low coupling are properly achieved.
+
+Added regression tests must comply with the following standards:
+1. Use `order_qt` prefix or manually add `order by` to ensure ordered results
+2. For cases expected to error, use the `test{sql,exception}` pattern
+3. After completing tests, do not drop tables; instead drop tables before using them in tests, to preserve the environment for debugging
+4. For ordinary single test tables, do not use `def tableName` form; instead hardcode your table name in all SQL
+5. Except for variables you explicitly need to adjust for testing current functionality, other variables do not need extra setup before testing. For example, nereids optimizer and pipeline engine settings can use default states
+
+## Commit Standards
+
+Files in git commit should only be related to the current modification task. Environment modifications for running (e.g., `conf/`, `AGENTS.md`, `hooks/`, etc.) must not be `git add`ed. When delivering the final task, you must ensure all actual code modifications have been committed.
+
+Commit messages must follow the format below, which mirrors the PR template (`.github/PULL_REQUEST_TEMPLATE.md`):
+
+```
+[<type>](<module>) <Short summary of the change>
+
+### What problem does this PR solve?
+
+Issue Number: close #xxx
+
+Related PR: #xxx
+
+Problem Summary: <Describe the problem this commit addresses>
+
+### Release note
+
+<If applicable, describe user-visible changes; otherwise write "None">
+
+### Check List (For Author)
+
+- Test: <Specify which testing was done>
+    - Regression test / Unit Test / Manual test / No need to test (with reason)
+- Behavior changed: No / Yes (with explanation)
+- Does this need documentation: No / Yes (with doc PR link)
+```
+
+Key rules for commit messages:
+1. The title must follow the `[type](module)` format validated by the PR title checker (`.github/workflows/title-checker.yml`). Common types include: `fix`, `feature`, `improvement`, `refactor`, `chore`, `test`, `doc`. Common modules include: `fe`, `be`, `cloud`, `regression`, `build`
+2. The short summary must be concise and written in imperative mood (e.g., `[fix](fe) Fix null pointer in scan node` not `[fix](fe) Fixed null pointer`)
+3. The `Issue Number` field must reference the corresponding GitHub Issue with `close #xxx` syntax when applicable
+4. The `Release note` section must be filled in for any user-visible behavior or feature change; write "None" for internal refactoring or test-only changes
+5. The test section must honestly reflect the testing performed; do not claim tests that were not actually run

--- a/be/src/cloud/AGENTS.md
+++ b/be/src/cloud/AGENTS.md
@@ -1,0 +1,20 @@
+# BE Cloud Module — Review Guide
+
+## Meta-Service RPC Pattern
+
+`retry_rpc` in `cloud_meta_mgr.cpp` wraps BE-to-meta-service RPC error handling.
+
+### Checkpoints
+
+- [ ] New meta-service RPCs reuse `retry_rpc` instead of open-coding retry?
+- [ ] `INVALID_ARGUMENT` returns immediately without retry?
+- [ ] `KV_TXN_CONFLICT` keeps its separate retry budget from generic retries?
+- [ ] Retry count, timeout, and backoff stay consistent with existing config pattern?
+
+## CloudTablet Sync
+
+- [ ] Lock order preserved: `_sync_meta_lock → _meta_lock`?
+- [ ] `sync_rowsets()` double-checks local max version before remote work?
+- [ ] Stale compaction-count detection checked against latest local counters before applying returned rowsets?
+- [ ] `NOT_FOUND` and full re-sync paths clear local version state before rebuilding?
+- [ ] `sync_if_not_running()` clears `_rs_version_map`, `_stale_rs_version_map`, and `_timestamped_version_tracker` before re-syncing?

--- a/be/src/common/AGENTS.md
+++ b/be/src/common/AGENTS.md
@@ -1,0 +1,29 @@
+# BE Common Module — Review Guide
+
+## Error Handling: Status / Exception / Result<T>
+
+| Type | Use | Propagation |
+|------|-----|-------------|
+| `Status` | Default error return | `RETURN_IF_ERROR` |
+| `Exception` | Vectorized hot paths | `RETURN_IF_CATCH_EXCEPTION` |
+| `Result<T>` | Value-or-error return | `DORIS_TRY` |
+
+### Checkpoints
+
+- [ ] Every `Status` return checked? Never `static_cast<void>(...)` to discard
+- [ ] Every `THROW_IF_ERROR` has a `RETURN_IF_CATCH_EXCEPTION` or `RETURN_IF_ERROR_OR_CATCH_EXCEPTION` above it?
+- [ ] `THROW_IF_ERROR` kept out of `Defer`, destructors, and stack-unwinding paths? Use `WARN_IF_ERROR` there
+- [ ] Thrift/RPC handlers convert Doris exceptions at the boundary?
+- [ ] `WARN_IF_ERROR` limited to cleanup/best-effort paths with non-empty message?
+- [ ] `DORIS_CHECK` for invariants only, never speculative defensive checks?
+- [ ] New catch blocks keep standard order: `doris::Exception` → `std::exception` → `...`?
+
+## compile_check Mechanism
+
+`compile_check_begin.h` / `compile_check_end.h` raise conversion warnings to errors.
+
+### Checkpoints
+
+- [ ] New declaration-heavy headers use paired `compile_check_begin.h` / `compile_check_end.h` matching neighbors?
+- [ ] Narrowing conversions avoided (`int64_t→int32_t`, `size_t→int`, `uint64_t→int64_t`)?
+- [ ] Third-party bypass uses `compile_check_avoid_begin.h` / `compile_check_avoid_end.h`, not local weakening?

--- a/be/src/core/AGENTS.md
+++ b/be/src/core/AGENTS.md
@@ -1,0 +1,32 @@
+# BE Core Module — Review Guide
+
+## COW Column Semantics
+
+Vectorized columns (`IColumn`) use intrusive-reference-counted copy-on-write.
+
+### Checkpoints
+
+- [ ] Exclusive ownership guaranteed before `mutate()` on hot paths? Shared ownership triggers deep copy
+- [ ] `assume_mutable_ref()` used only when exclusive ownership is already guaranteed?
+- [ ] After `Block::mutate_columns()`, columns put back with `set_columns()`?
+- [ ] `convert_to_full_column_if_const()` materializes only `ColumnConst`; ordinary columns may return shared storage?
+
+## Type System and Serialization
+
+### Upgrade/Downgrade Compatibility
+
+- [ ] Serialized block/datatype layout changes gated with `be_exec_version` where required?
+- [ ] Old and new serialization branches updated together (byte-size, serialize, deserialize)?
+
+### Decimal and Type Metadata
+
+- [ ] Decimal result types check precision growth limits, no accidental incompatible widening?
+- [ ] `DecimalV2` `original_precision`/`original_scale` set intentionally, not left as `UINT32_MAX` sentinel?
+- [ ] `TScalarType` optional fields filled for DECIMAL, CHAR/VARCHAR, DATETIMEV2?
+- [ ] Flattened `TTypeDesc.types` traversal correct for nested complex types?
+
+## Block Merge Nullable Trap
+
+`MutableBlock::merge_impl()` assumes nullable promotion shape without dynamic checking in release builds.
+
+- [ ] New block merge logic preserves nullable-promotion preconditions?

--- a/be/src/exec/AGENTS.md
+++ b/be/src/exec/AGENTS.md
@@ -1,0 +1,26 @@
+# BE Exec Module — Review Guide
+
+## Pipeline Execution
+
+### Operator Lifecycle
+
+Tasks move through `INITED → RUNNABLE → BLOCKED → FINISHED → FINALIZED`.
+
+- [ ] `SharedState` source/sink dependencies connected through `inject_shared_state()`?
+
+### Memory Reservation and Spill
+
+- [ ] Memory-heavy operators use `_try_to_reserve_memory()` before materializing large structures?
+- [ ] `_memory_sufficient_dependency` wired in where pressure should block, not overrun?
+- [ ] `revoke_memory()` preserves the existing spill path?
+
+## Dependency Concurrency
+
+- [ ] Default readiness preserved? Source starts blocked; sink starts ready
+- [ ] `set_ready()` fast-path precheck vs `is_blocked_by()` lock-first asymmetry respected?
+- [ ] New `Dependency` subclasses pair `block()` / `set_ready()` on every path?
+- [ ] `CountedFinishDependency::add()` and `sub()` under `_mtx`?
+
+## Atomics
+
+- [ ] Relaxed atomics only for statistics; lifecycle/stop flags use at least acquire/release?

--- a/be/src/io/AGENTS.md
+++ b/be/src/io/AGENTS.md
@@ -1,0 +1,4 @@
+# BE IO — Review Guide
+
+- [ ] Public `FileSystem` operations use `FILESYSTEM_M` (inline on pthreads, `AsyncIO::run_task` on bthreads)?
+- [ ] Remote-reader caching stays at `RemoteFileSystem::open_file_impl()`, not reimplemented per backend?

--- a/be/src/runtime/AGENTS.md
+++ b/be/src/runtime/AGENTS.md
@@ -1,0 +1,35 @@
+# BE Runtime Module — Review Guide
+
+## MemTracker Hierarchy
+
+Two levels: `MemTrackerLimiter` (heavyweight, with limits) and `MemTracker` (lightweight, nested accounting). Thread-local state via `ThreadMemTrackerMgr`.
+
+### Checkpoints
+
+- [ ] Task-bound threads/bthreads enter with `SCOPED_ATTACH_TASK`?
+- [ ] Non-task background threads use `SCOPED_INIT_THREAD_CONTEXT`?
+- [ ] Temporary limiter switching uses `SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER`, not manual save/restore?
+- [ ] Thread-pool callbacks attach at callback entry, not deeper in the call chain?
+- [ ] Large allocations use `try_reserve()` with `DEFER_RELEASE_RESERVED()` for balanced accounting on every exit?
+- [ ] Code reachable from `ThreadMemTrackerMgr::consume` avoids operations that may allocate recursively?
+
+## Object Lifecycle
+
+- [ ] `ENABLE_FACTORY_CREATOR` classes use `create_shared()` / `create_unique()`, not raw `new`?
+- [ ] Ownership cycles broken with `weak_ptr` or raw observer pointers?
+- [ ] Single-owner paths use `unique_ptr` plus observer raw pointers?
+
+## Cache Lifecycle
+
+- [ ] Every `Cache::Handle*` released after use?
+- [ ] Cache values inherit `LRUCacheValueBase` for tracked-byte release?
+- [ ] New caches registered with `CacheManager` for global GC?
+
+## Static Initialization
+
+- [ ] New namespace-scope static/global depends on another TU's object? That is a SIOF hazard
+- [ ] Fix: `constexpr`, same-header `inline`, or function-local static?
+
+## Workload Group Memory
+
+- [ ] When precise limit enforcement matters, code uses `check_mem_used()` not just `exceed_limit()`?

--- a/be/src/storage/AGENTS.md
+++ b/be/src/storage/AGENTS.md
@@ -1,0 +1,35 @@
+# BE Storage Module — Review Guide
+
+## Tablet Locks
+
+| Lock | Type | Role |
+|------|------|------|
+| `_meta_lock` | `shared_mutex` | Version maps and tablet metadata visibility |
+| `_rowset_update_lock` | `mutex` | Serializes delete bitmap updates (publish / MoW) |
+| `_base_compaction_lock` | `mutex` | Serializes base compaction |
+| `_cumulative_compaction_lock` | `mutex` | Serializes cumulative compaction |
+
+### Checkpoints
+
+- [ ] `_rs_version_map` and `_stale_rs_version_map` accessed under `_meta_lock` with correct shared/exclusive mode?
+- [ ] Tablet-meta mutations under exclusive `_meta_lock`?
+- [ ] Nested locking follows established preconditions? (`update_delete_bitmap_without_lock()` requires both `_rowset_update_lock` and `_meta_lock`)
+- [ ] TxnManager lock order: `_txn_lock → _txn_map_lock`?
+
+## Rowset and Version Lifecycle
+
+- [ ] `add_rowset()` / `modify_rowsets()` under exclusive `_meta_lock`?
+- [ ] Version continuity preserved, or intentional same-version replacement used correctly?
+- [ ] Same-version replacement: old rowset moved to unused-rowset tracking before new becomes authoritative?
+- [ ] Reader/rowset code respects split lifetime: `shared_ptr` ownership + reader `acquire()` / `release()`?
+- [ ] `StorageEngine::_unused_rowsets` deletable only when `use_count() == 1`?
+
+## Delete Bitmap (MoW)
+
+- [ ] Cloud mode: `TEMP_VERSION_COMMON` and sentinels replaced before bitmap use?
+- [ ] Bitmap calculation serialized under `_rowset_update_lock`?
+- [ ] Compaction bitmap uses latest compaction counters, not stale snapshots?
+
+## Segment Writing
+
+- [ ] MoW tables: `SegmentWriterOptions::enable_unique_key_merge_on_write` set to `true` on every path?

--- a/be/src/storage/index/inverted/AGENTS.md
+++ b/be/src/storage/index/inverted/AGENTS.md
@@ -1,0 +1,17 @@
+# Inverted Index — Review Guide
+
+## Lifecycle
+
+- [ ] Field declaration order preserves `_dir` before `_index_writer` lifetime dependency?
+- [ ] Cache-facing code uses `InvertedIndexCacheHandle` over raw handles for paired release/retention?
+
+## CLucene Boundary
+
+CLucene uses `ErrorContext` + local FINALLY helpers, not Doris exception flow.
+
+- [ ] New CLucene integrations use `ErrorContext` + `FINALLY` / `FINALLY_CLOSE` / `FINALLY_EXCEPTION`, not ad hoc try/catch?
+
+## Three-Valued Logic Bitmap
+
+- [ ] Bitmap logic preserves SQL three-valued semantics across `_data_bitmap` and `_null_bitmap`?
+- [ ] `op_not` is `const` in signature but mutates shared state — callers handle this?

--- a/be/src/storage/schema_change/AGENTS.md
+++ b/be/src/storage/schema_change/AGENTS.md
@@ -1,0 +1,25 @@
+# Schema Change — Review Guide
+
+## Strategy Selection
+
+Three strategies: `LinkedSchemaChange` (metadata-only), `VSchemaChangeDirectly` (rewrite, no sort), `VLocalSchemaChangeWithSorting` (full rewrite with sort).
+
+- [ ] Request classification flows through the existing parse-and-dispatch path?
+
+## Lock Order
+
+Required: `base_tablet push_lock → new_tablet push_lock → base_tablet header_lock → new_tablet header_lock`
+
+- [ ] Four-level order preserved?
+
+## MoW Delete Bitmap Flow
+
+Staged flow: (1) dual-write rowsets skip immediate bitmap calc → (2) converted rowsets catch up bitmaps → (3) new publish blocked during incremental catch-up → (4) state switches to `TABLET_RUNNING`.
+
+- [ ] Four-step ordering preserved exactly?
+- [ ] Base and cumulative compaction locks held before MoW delete bitmap calculation?
+
+## Dropped-Column Trap
+
+- [ ] `return_columns` derived before dropped columns merged? (Dropped columns needed for delete-predicate evaluation)
+- [ ] `ignore_schema_change_check` stays an explicit escape hatch, not normal production behavior?

--- a/cloud/src/meta-service/AGENTS.md
+++ b/cloud/src/meta-service/AGENTS.md
@@ -1,0 +1,20 @@
+# Cloud Meta-Service — Review Guide
+
+## Transaction Commit Paths
+
+Two paths: `commit_txn_immediately` and `commit_txn_eventually`.
+
+- [ ] Path selection consistent with existing rules: 2PC state, lazy-commit switches, rowset-count threshold, fuzz forcing, `TXN_BYTES_TOO_LARGE` fallback?
+- [ ] `commit_txn_immediately` restart on pending lazy-committed txns has clear timeout/termination story?
+- [ ] Begin-txn id allocation preserves label-plus-versionstamp pattern?
+
+## RPC Boundary
+
+- [ ] New handlers have `RPC_PREPROCESS` and `RPC_RATE_LIMIT`?
+- [ ] `MetaServiceCode` set on every return path?
+- [ ] Handlers idempotent under `MetaServiceProxy` retries for `KV_TXN_STORE_*_RETRYABLE`, `KV_TXN_MAYBE_COMMITTED`, `KV_TXN_TOO_OLD`, and `KV_TXN_CONFLICT` (when conflict retry enabled)?
+
+## Cloud MoW
+
+- [ ] Responses tolerate sentinel marks and `TEMP_VERSION_COMMON` that BE must rewrite before use?
+- [ ] Commit/publish changes keep version and compaction metadata consistent with BE delete bitmap calculation?

--- a/cloud/src/meta-store/AGENTS.md
+++ b/cloud/src/meta-store/AGENTS.md
@@ -1,0 +1,19 @@
+# Cloud Meta-Store — Review Guide
+
+## TxnKv
+
+- [ ] Every `TxnErrorCode` result handled?
+- [ ] `TXN_MAYBE_COMMITTED` treated as ambiguous, requiring idempotent recheck/retry at caller?
+- [ ] Transaction-size limit respected (no assumption TxnKv absorbs arbitrarily large writes)?
+
+## Key Encoding
+
+- [ ] Key families from `keys.h` helpers, not hand-built prefixes?
+- [ ] Correct space: `0x01` current metadata, `0x02` system/meta-service, `0x03` versioned historical/auxiliary?
+- [ ] `encode_bytes()` / `encode_int64()` with field order matching intended scan prefix?
+- [ ] `0x03` versioned values use existing helpers, not open-coded KV layouts?
+
+## Versionstamp
+
+- [ ] Versionstamped writes use `atomic_set_ver_key()` / `atomic_set_ver_value()` helpers?
+- [ ] `get_versionstamp()` called only after successful commit?

--- a/cloud/src/recycler/AGENTS.md
+++ b/cloud/src/recycler/AGENTS.md
@@ -1,0 +1,6 @@
+# Cloud Recycler — Review Guide
+
+- [ ] Mark-before-delete two-phase flow preserved: mark `is_recycled` first, delete physical data in later round?
+- [ ] Abort-before-delete aligned with origin: load rowsets abort txns, compaction/schema-change rowsets abort jobs?
+- [ ] Packed files: fix metadata → delete object storage → reread KV → remove KV only if still recyclable?
+- [ ] Conflict/retry paths idempotent and restart-safe? (Recycler phases often fail fast, not best-effort)

--- a/fe/AGENTS.md
+++ b/fe/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md — Apache Doris FE
+
+## Build Instructions
+
+### 0. Verify protoc executable
+
+Ensure `thirdparty/installed/bin/protoc` exists and is executable. If it does not exist, **stop the build** and prompt the user to download the thirdparty libraries first.
+
+### 1. Generate sources
+
+Run from the repository root:
+
+```bash
+sh generated-source.sh
+```
+
+### 2. Build FE
+
+```bash
+cd fe && mvn clean install -DskipTests -Dskip.doc=true -T 1C
+```

--- a/fe/fe-core/AGENTS.md
+++ b/fe/fe-core/AGENTS.md
@@ -1,0 +1,20 @@
+# FE Core Module — Review Guide
+
+## Locking
+
+- [ ] Metadata-locking paths avoid RPC, external IO, and journal waits while holding catalog/database/table locks?
+- [ ] Multiple tables locked in ID-sorted order?
+- [ ] Existing `tryLock(timeout)` patterns preserved, not replaced with unbounded blocking?
+- [ ] No database/catalog locks taken inside broad `synchronized` blocks or async callbacks?
+- [ ] Shared `Map`/`List` traversals protected by locking, snapshots, or concurrent containers against `ConcurrentModificationException`?
+
+## Exceptions
+
+- [ ] FE-common `AnalysisException` (checked) vs Nereids' `AnalysisException` (unchecked) distinguished correctly?
+- [ ] User-visible errors use `ErrorReport`/`ErrorCode` with custom codes starting at 5000?
+- [ ] RPC boundaries convert to `TStatusCode`/`PStatus`, not leaking Java exceptions?
+
+## Visible Version
+
+- [ ] `OlapTable.getVisibleVersion()` respects cloud/non-cloud split: local in shared-nothing, RPC+TTL cache in cloud?
+- [ ] Cloud `VERSION_NOT_FOUND` normalized to `PARTITION_INIT_VERSION` — "missing" and version 1 intentionally indistinguishable?

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/AGENTS.md
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/AGENTS.md
@@ -1,0 +1,13 @@
+# Backup/Restore — Review Guide
+
+## BackupJob State Machine
+
+- [ ] `PENDING → SNAPSHOTING` no-EditLog transition preserved? (Restart regenerates snapshot tasks)
+- [ ] Snapshot prep writes `BarrierLog` and stores commit sequence?
+- [ ] `UPLOAD_INFO` failures retry until timeout, not cancel immediately?
+
+## RestoreJob Replay
+
+- [ ] Early redoable stages that skip EditLog remain restart-replayable from earlier persisted state?
+- [ ] `state` is persistent truth; `showState` is display-only, advanced only after finish log is durable?
+- [ ] Finish ordering preserved: `logRestoreJob(this)` → snapshot cleanup → `showState` update?

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/AGENTS.md
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/AGENTS.md
@@ -1,0 +1,8 @@
+# External Catalog — Review Guide
+
+## Initialization and Reset
+
+- [ ] Code avoids relying on `ExternalCatalog.isInitializing` as reentrancy guard? (Checked but never set to `true`)
+- [ ] `getFilteredDatabaseNames()` changes keep `lowerCaseToDatabaseName` update atomic/consistent with refill semantics?
+- [ ] `lower_case_database_names` behavior and case-insensitive lookup mapping preserved?
+- [ ] `resetToUninitialized()` avoids exposing partially torn-down state to in-flight readers?

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/AGENTS.md
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/AGENTS.md
@@ -1,0 +1,21 @@
+# Nereids Optimizer — Review Guide
+
+## Rules
+
+- [ ] New rule has correct `RuleType` and registration path?
+- [ ] Join rewrites handle all `JoinType` values and preserve mark-join semantics (`markJoinSlotReference`)?
+- [ ] Constant predicates and `containsUniqueFunction()` handled before pushdown/inference?
+- [ ] No rewrite-loop risk from nodes recreated into a shape matched again in the same stage?
+- [ ] Wrapper-shape requirements (e.g. `project(join)`) preserved?
+
+## Stage Order
+
+- [ ] New rewrite rule placed in correct stage w.r.t. dependencies (esp. `PUSH_DOWN_FILTERS`, `InferPredicates`)?
+- [ ] Exploration/implementation rules in correct `RuleSet` entry points?
+
+## Property Derivation
+
+- [ ] New physical operator has `RequestPropertyDeriver` logic?
+- [ ] All viable property alternatives exposed, not prematurely narrowed to one distribution?
+- [ ] Mark join restriction: standalone mark join is broadcast-only?
+- [ ] `PhysicalProject` alias penetration limited to bare `SlotRef` and `Alias(SlotRef)`?

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/AGENTS.md
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/AGENTS.md
@@ -1,0 +1,21 @@
+# EditLog / Persistence — Review Guide
+
+## Write and Replay
+
+- [ ] Every metadata state change has both a write-side EditLog call and matching replay in `EditLog.loadJournal()`?
+- [ ] Replay logic equivalent to master-side transition, not approximate reconstruction?
+- [ ] New persisted objects have complete Gson annotations and image/checkpoint coverage?
+- [ ] Master failover at any point avoids duplicate state, missing state, and leaked txn metadata?
+
+## Transaction EditLog Modes
+
+`DatabaseTransactionMgr` supports inside-lock and outside-lock persistence.
+
+- [ ] Both modes kept correct for transaction changes?
+- [ ] PREPARE transactions from non-`FRONTEND` sources intentionally not journaled?
+- [ ] Outside-lock mode: all in-memory mutations complete before `submitEdit()`, since other threads observe new state immediately?
+- [ ] `awaitTransactionState()` kept outside write lock? (Unbounded wait, not timeout-based)
+
+## Fatal Errors
+
+- [ ] EditLog flush failures not swallowed? FE exits on durable-log failure to prevent split brain

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/AGENTS.md
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/AGENTS.md
@@ -1,0 +1,16 @@
+# Transaction Management — Review Guide
+
+## Lifecycle
+
+State machine: `PREPARE → COMMITTED → VISIBLE` or `ABORTED`.
+
+- [ ] `PublishVersionDaemon` builds and sends publish work to every relevant backend?
+- [ ] Publish-finish semantics preserved (more complex than simple quorum check)?
+- [ ] Timeout/abort paths release state cleanly, no partially visible metadata left?
+- [ ] `TransactionState.tableIdList` (unsynchronized `ArrayList`) mutated only under external serialization?
+- [ ] Multi-table local transaction paths use ID-sorted locking?
+
+## Cloud Mode
+
+- [ ] Cloud paths use `CloudGlobalTransactionMgr` through interface methods, not concrete-type assumptions?
+- [ ] No unsafe downcasts from `GlobalTransactionMgrIface`?


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Port the AI code-review skill (`SKILL.md`) and module-specific coding guidelines (`AGENTS.md`) from the `master` branch to `branch-3.1`. This provides AI-assisted code review capabilities aligned with Doris core standards directly within the 3.1 worktree.

Modifications made for 3.1 compatibility:
- Added a fallback rule in `SKILL.md` to gracefully handle cases where `master` APIs (e.g., `Result<T>`) are missing in `branch-3.1`.
- Added a compatibility warning in the root `AGENTS.md` to prioritize existing `branch-3.1` conventions over strict adherence to new architectural paradigms from `master`.

### Release note

None

### Check List (For Author)

- Test: No need to test (This PR only adds documentation and AI assistant configurations, no logic changes)
- Behavior changed: No
- Does this need documentation: No