### PR TITLE
[fix](fe) Fix broken pipe risk on stream load redirect with unconsumed request body

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -438,6 +438,13 @@ public class Config extends ConfigBase {
             "The maximum HTTP POST size of Jetty, in bytes, the default value is 100MB."})
     public static int jetty_server_max_http_post_size = 100 * 1024 * 1024;
 
+    @ConfField(mutable = true, description = {
+            "Jetty 在应用未消费完请求体时，额外尝试读取剩余内容的最大次数。"
+                    + "-1 表示不限制，0 表示不额外读取，正数表示最大读取次数。",
+            "The maximum number of extra reads Jetty performs for unconsumed request content. "
+                    + "-1 means unlimited, 0 means disabled, and a positive value limits the read attempts."})
+    public static int jetty_server_max_unconsumed_request_content_reads = -1;
+
     @ConfField(description = {"Jetty 的最大 HTTP header 大小，单位是字节，默认值是 1MB。",
             "The maximum HTTP header size of Jetty, in bytes, the default value is 1MB."})
     public static int jetty_server_max_http_header_size = 1048576;
@@ -3304,6 +3311,13 @@ public class Config extends ConfigBase {
             "streamload route policy, available options are "
             + "public-private/public/private/direct/random-be and empty string" })
     public static String streamload_redirect_policy = "";
+
+    @ConfField(mutable = true, description = {
+            "Stream Load redirect 场景下，FE 在返回 307 后额外丢弃请求体的最大字节数。"
+                    + "0 表示关闭该兼容逻辑，正数表示最大丢弃字节数。",
+            "The maximum number of request body bytes FE drains after returning 307 for Stream Load redirects. "
+                    + "0 disables the compatibility logic, and a positive value sets the byte limit."})
+    public static long stream_load_redirect_bounded_drain_max_bytes = 0;
 
     @ConfField(mutable = true, description = {
             "存算分离模式下是否启用group commit的streamload BE转发功能。"

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3317,7 +3317,7 @@ public class Config extends ConfigBase {
                     + "0 表示关闭该兼容逻辑，正数表示最大丢弃字节数。",
             "The maximum number of request body bytes FE drains after returning 307 for Stream Load redirects. "
                     + "0 disables the compatibility logic, and a positive value sets the byte limit."})
-    public static long stream_load_redirect_bounded_drain_max_bytes = 0;
+    public static long stream_load_redirect_bounded_drain_max_bytes = 1024L * 1024 * 1024;
 
     @ConfField(mutable = true, description = {
             "Stream Load redirect 场景下，FE 在检测到请求体暂时无可读数据后继续等待的最大空闲时长，单位毫秒。"
@@ -3325,7 +3325,7 @@ public class Config extends ConfigBase {
             "The maximum idle wait time in milliseconds after FE detects no readable request body bytes "
                     + "during Stream Load redirect drain. 0 disables the extra idle wait, while a positive value "
                     + "keeps a bounded grace window for slow clients or delayed request body chunks."})
-    public static int stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+    public static int stream_load_redirect_bounded_drain_max_idle_time_ms = 1000;
 
     @ConfField(mutable = true, description = {
             "存算分离模式下是否启用group commit的streamload BE转发功能。"

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -440,10 +440,11 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true, description = {
             "Jetty 在应用未消费完请求体时，额外尝试读取剩余内容的最大次数。"
-                    + "-1 表示不限制，0 表示不额外读取，正数表示最大读取次数。",
+                    + "0 表示保持 Jetty 默认行为，-1 表示不限制，正数表示最大读取次数。",
             "The maximum number of extra reads Jetty performs for unconsumed request content. "
-                    + "-1 means unlimited, 0 means disabled, and a positive value limits the read attempts."})
-    public static int jetty_server_max_unconsumed_request_content_reads = -1;
+                    + "0 keeps Jetty's default behavior, -1 means unlimited, and a positive value limits "
+                    + "the read attempts."})
+    public static int jetty_server_max_unconsumed_request_content_reads = 0;
 
     @ConfField(description = {"Jetty 的最大 HTTP header 大小，单位是字节，默认值是 1MB。",
             "The maximum HTTP header size of Jetty, in bytes, the default value is 1MB."})

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3320,6 +3320,14 @@ public class Config extends ConfigBase {
     public static long stream_load_redirect_bounded_drain_max_bytes = 0;
 
     @ConfField(mutable = true, description = {
+            "Stream Load redirect 场景下，FE 在检测到请求体暂时无可读数据后继续等待的最大空闲时长，单位毫秒。"
+                    + "0 表示不额外等待，用于给慢客户端或分段到达的数据保留一个有限的缓冲窗口。",
+            "The maximum idle wait time in milliseconds after FE detects no readable request body bytes "
+                    + "during Stream Load redirect drain. 0 disables the extra idle wait, while a positive value "
+                    + "keeps a bounded grace window for slow clients or delayed request body chunks."})
+    public static int stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+
+    @ConfField(mutable = true, description = {
             "存算分离模式下是否启用group commit的streamload BE转发功能。"
                     + "解决LB随机转发导致group commit攒批失效的问题，通过BE二次转发确保同表请求到达同一BE节点。",
             "Whether to enable group commit streamload BE forward feature in cloud mode. "

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3318,7 +3318,7 @@ public class Config extends ConfigBase {
             "The maximum idle wait time in milliseconds after FE detects no readable request body bytes "
                     + "during Stream Load redirect drain. 0 disables the extra idle wait, while a positive value "
                     + "keeps a bounded grace window for slow clients or delayed request body chunks."})
-    public static int stream_load_redirect_bounded_drain_max_idle_time_ms = 1000;
+    public static int stream_load_redirect_bounded_drain_max_idle_time_ms = 10000;
 
     @ConfField(mutable = true, description = {
             "存算分离模式下是否启用group commit的streamload BE转发功能。"

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -438,14 +438,6 @@ public class Config extends ConfigBase {
             "The maximum HTTP POST size of Jetty, in bytes, the default value is 100MB."})
     public static int jetty_server_max_http_post_size = 100 * 1024 * 1024;
 
-    @ConfField(mutable = true, description = {
-            "Jetty 在应用未消费完请求体时，额外尝试读取剩余内容的最大次数。"
-                    + "0 表示保持 Jetty 默认行为，-1 表示不限制，正数表示最大读取次数。",
-            "The maximum number of extra reads Jetty performs for unconsumed request content. "
-                    + "0 keeps Jetty's default behavior, -1 means unlimited, and a positive value limits "
-                    + "the read attempts."})
-    public static int jetty_server_max_unconsumed_request_content_reads = 0;
-
     @ConfField(description = {"Jetty 的最大 HTTP header 大小，单位是字节，默认值是 1MB。",
             "The maximum HTTP header size of Jetty, in bytes, the default value is 1MB."})
     public static int jetty_server_max_http_header_size = 1048576;

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3310,7 +3310,7 @@ public class Config extends ConfigBase {
                     + "0 表示关闭该兼容逻辑，正数表示最大丢弃字节数。",
             "The maximum number of request body bytes FE drains after returning 307 for Stream Load redirects. "
                     + "0 disables the compatibility logic, and a positive value sets the byte limit."})
-    public static long stream_load_redirect_bounded_drain_max_bytes = 1024L * 1024 * 1024;
+    public static long stream_load_redirect_bounded_drain_max_bytes = 2L * 1024 * 1024 * 1024;
 
     @ConfField(mutable = true, description = {
             "Stream Load redirect 场景下，FE 在检测到请求体暂时无可读数据后继续等待的最大空闲时长，单位毫秒。"

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
@@ -19,6 +19,7 @@ package org.apache.doris.httpv2.config;
 
 import org.apache.doris.common.Config;
 
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.ServerConnector;
@@ -37,12 +38,16 @@ public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomi
             ((JettyServletWebServerFactory) factory).setConfigurations(
                     Collections.singletonList(new HttpToHttpsJettyConfig())
             );
+        }
 
-            factory.addServerCustomizers(
-                    server -> {
+        factory.addServerCustomizers(
+                server -> {
+                    if (Config.enable_https) {
                         HttpConfiguration httpConfiguration = new HttpConfiguration();
                         httpConfiguration.setSecurePort(Config.https_port);
                         httpConfiguration.setSecureScheme("https");
+                        httpConfiguration.setMaxUnconsumedRequestContentReads(
+                                Config.jetty_server_max_unconsumed_request_content_reads);
 
                         ServerConnector connector = new ServerConnector(server);
                         connector.addConnectionFactory(new HttpConnectionFactory(httpConfiguration));
@@ -50,7 +55,19 @@ public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomi
 
                         server.addConnector(connector);
                     }
-            );
-        }
+
+                    for (Connector connector : server.getConnectors()) {
+                        if (!(connector instanceof ServerConnector)) {
+                            continue;
+                        }
+                        HttpConnectionFactory httpConnectionFactory =
+                                ((ServerConnector) connector).getConnectionFactory(HttpConnectionFactory.class);
+                        if (httpConnectionFactory != null) {
+                            httpConnectionFactory.getHttpConfiguration().setMaxUnconsumedRequestContentReads(
+                                    Config.jetty_server_max_unconsumed_request_content_reads);
+                        }
+                    }
+                }
+        );
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
@@ -40,6 +40,25 @@ public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomi
             );
         }
 
+        if (Config.jetty_server_max_unconsumed_request_content_reads == 0) {
+            if (Config.enable_https) {
+                factory.addServerCustomizers(
+                        server -> {
+                            HttpConfiguration httpConfiguration = new HttpConfiguration();
+                            httpConfiguration.setSecurePort(Config.https_port);
+                            httpConfiguration.setSecureScheme("https");
+
+                            ServerConnector connector = new ServerConnector(server);
+                            connector.addConnectionFactory(new HttpConnectionFactory(httpConfiguration));
+                            connector.setPort(Config.http_port);
+
+                            server.addConnector(connector);
+                        }
+                );
+            }
+            return;
+        }
+
         factory.addServerCustomizers(
                 server -> {
                     if (Config.enable_https) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
@@ -19,7 +19,6 @@ package org.apache.doris.httpv2.config;
 
 import org.apache.doris.common.Config;
 
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.ServerConnector;
@@ -38,35 +37,12 @@ public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomi
             ((JettyServletWebServerFactory) factory).setConfigurations(
                     Collections.singletonList(new HttpToHttpsJettyConfig())
             );
-        }
 
-        if (Config.jetty_server_max_unconsumed_request_content_reads == 0) {
-            if (Config.enable_https) {
-                factory.addServerCustomizers(
-                        server -> {
-                            HttpConfiguration httpConfiguration = new HttpConfiguration();
-                            httpConfiguration.setSecurePort(Config.https_port);
-                            httpConfiguration.setSecureScheme("https");
-
-                            ServerConnector connector = new ServerConnector(server);
-                            connector.addConnectionFactory(new HttpConnectionFactory(httpConfiguration));
-                            connector.setPort(Config.http_port);
-
-                            server.addConnector(connector);
-                        }
-                );
-            }
-            return;
-        }
-
-        factory.addServerCustomizers(
-                server -> {
-                    if (Config.enable_https) {
+            factory.addServerCustomizers(
+                    server -> {
                         HttpConfiguration httpConfiguration = new HttpConfiguration();
                         httpConfiguration.setSecurePort(Config.https_port);
                         httpConfiguration.setSecureScheme("https");
-                        httpConfiguration.setMaxUnconsumedRequestContentReads(
-                                Config.jetty_server_max_unconsumed_request_content_reads);
 
                         ServerConnector connector = new ServerConnector(server);
                         connector.addConnectionFactory(new HttpConnectionFactory(httpConfiguration));
@@ -74,19 +50,7 @@ public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomi
 
                         server.addConnector(connector);
                     }
-
-                    for (Connector connector : server.getConnectors()) {
-                        if (!(connector instanceof ServerConnector)) {
-                            continue;
-                        }
-                        HttpConnectionFactory httpConnectionFactory =
-                                ((ServerConnector) connector).getConnectionFactory(HttpConnectionFactory.class);
-                        if (httpConnectionFactory != null) {
-                            httpConnectionFactory.getHttpConfiguration().setMaxUnconsumedRequestContentReads(
-                                    Config.jetty_server_max_unconsumed_request_content_reads);
-                        }
-                    }
-                }
-        );
+            );
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -334,8 +334,15 @@ public class LoadAction extends RestBaseController {
 
             return createRedirectResponse(request, response, redirectAddr, isStreamLoad, dbName, tableName, label);
         } catch (StreamLoadForwardException e) {
-            // Special handling for stream load forwarding
-            return createRedirectResponse(request, response, e.getRedirectView(), isStreamLoad, db, table, label);
+            // Handle IOException from redirect response generation in the forwarding path.
+            try {
+                return createRedirectResponse(request, response, e.getRedirectView(),
+                        isStreamLoad, db, table, label);
+            } catch (IOException ioException) {
+                LOG.warn("stream load forward redirect failed, stream: {}, db: {}, tbl: {}, label: {}, err: {}",
+                        isStreamLoad, db, table, label, ioException.getMessage());
+                return new RestBaseResult(ioException.getMessage());
+            }
         } catch (Exception e) {
             LOG.warn("load failed, stream: {}, db: {}, tbl: {}, label: {}, err: {}",
                     isStreamLoad, db, table, label, e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -23,7 +23,6 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.cloud.qe.ComputeGroupException;
-import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
@@ -38,6 +37,7 @@ import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.entity.RestBaseResult;
 import org.apache.doris.httpv2.exception.UnauthorizedException;
 import org.apache.doris.httpv2.rest.manager.HttpUtils;
+import org.apache.doris.httpv2.util.StreamLoadRedirectDrainUtil;
 import org.apache.doris.load.FailMsg;
 import org.apache.doris.load.StreamLoadHandler;
 import org.apache.doris.load.loadv2.IngestionLoadJob;
@@ -77,7 +77,6 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.URI;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -210,8 +209,7 @@ public class LoadAction extends RestBaseController {
             LOG.info("redirect load action to destination={}, label: {}",
                     redirectAddr.toString(), label);
 
-            RedirectView redirectView = redirectTo(request, redirectAddr);
-            return redirectView;
+            return createRedirectResponse(request, response, redirectAddr, true, null, null, label);
         } catch (Exception e) {
             return new RestBaseResult(e.getMessage());
         }
@@ -334,11 +332,10 @@ public class LoadAction extends RestBaseController {
                         redirectAddr.toString(), isStreamLoad, dbName, tableName, label);
             }
 
-            RedirectView redirectView = redirectTo(request, redirectAddr);
-            return redirectView;
+            return createRedirectResponse(request, response, redirectAddr, isStreamLoad, dbName, tableName, label);
         } catch (StreamLoadForwardException e) {
             // Special handling for stream load forwarding
-            return e.getRedirectView();
+            return createRedirectResponse(request, response, e.getRedirectView(), isStreamLoad, db, table, label);
         } catch (Exception e) {
             LOG.warn("load failed, stream: {}, db: {}, tbl: {}, label: {}, err: {}",
                     isStreamLoad, db, table, label, e.getMessage());
@@ -672,24 +669,7 @@ public class LoadAction extends RestBaseController {
                             + "stream: {}, db: {}, tbl: {}, label: {}",
                     redirectAddr.toString(), isStreamLoad, dbName, tableName, label);
 
-            URI urlObj = null;
-            URI resultUriObj = null;
-            String urlStr = request.getRequestURI();
-            String userInfo = null;
-
-            try {
-                urlObj = new URI(urlStr);
-                resultUriObj = new URI("http", userInfo, redirectAddr.getHostname(),
-                        redirectAddr.getPort(), urlObj.getPath(), "", null);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            String redirectUrl = resultUriObj.toASCIIString();
-            if (!Strings.isNullOrEmpty(request.getQueryString())) {
-                redirectUrl += request.getQueryString();
-            }
-            LOG.info("Redirect url: {}", "http://" + redirectAddr.getHostname() + ":"
-                    + redirectAddr.getPort() + urlObj.getPath());
+            String redirectUrl = buildRedirectUrl(request, redirectAddr);
             RedirectView redirectView = new RedirectView(redirectUrl);
             redirectView.setContentType("text/html;charset=utf-8");
             redirectView.setStatusCode(org.springframework.http.HttpStatus.TEMPORARY_REDIRECT);
@@ -712,6 +692,47 @@ public class LoadAction extends RestBaseController {
             headers.append(headerName).append(":").append(headerValue).append(", ");
         }
         return headers.toString();
+    }
+
+    private Object createRedirectResponse(HttpServletRequest request, HttpServletResponse response,
+            TNetworkAddress redirectAddr, boolean isStreamLoad, String dbName, String tableName, String label)
+            throws IOException {
+        String redirectUrl = buildRedirectUrl(request, redirectAddr);
+        if (!shouldUseBoundedDrainForStreamLoad(isStreamLoad)) {
+            return redirectTo(request, redirectAddr);
+        }
+        writeTemporaryRedirect(response, redirectUrl);
+        drainStreamLoadRequestBodyAfterRedirect(request, redirectAddr.toString(), dbName, tableName, label);
+        return null;
+    }
+
+    private Object createRedirectResponse(HttpServletRequest request, HttpServletResponse response,
+            RedirectView redirectView, boolean isStreamLoad, String dbName, String tableName, String label)
+            throws IOException {
+        if (!shouldUseBoundedDrainForStreamLoad(isStreamLoad)) {
+            return redirectView;
+        }
+        writeTemporaryRedirect(response, redirectView.getUrl());
+        drainStreamLoadRequestBodyAfterRedirect(request, redirectView.getUrl(), dbName, tableName, label);
+        return null;
+    }
+
+    private boolean shouldUseBoundedDrainForStreamLoad(boolean isStreamLoad) {
+        return isStreamLoad && Config.stream_load_redirect_bounded_drain_max_bytes > 0;
+    }
+
+    private void drainStreamLoadRequestBodyAfterRedirect(HttpServletRequest request, String redirectTarget,
+            String dbName, String tableName, String label) {
+        long drainLimit = Config.stream_load_redirect_bounded_drain_max_bytes;
+        LOG.info("write stream load redirect and start bounded drain, target: {}, db: {}, tbl: {}, label: {},"
+                        + " max_drain_bytes: {}",
+                redirectTarget, dbName, tableName, label, drainLimit);
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(request, drainLimit);
+        LOG.info("finish bounded drain after stream load redirect, target: {}, db: {}, tbl: {}, label: {},"
+                        + " drained_bytes: {}, elapsed_ms: {}, exit_reason: {}",
+                redirectTarget, dbName, tableName, label, drainResult.getDrainedBytes(),
+                drainResult.getElapsedMillis(), drainResult.getExitReason());
     }
 
     private Backend selectBackendForGroupCommit(String clusterName, HttpServletRequest req, long tableId)
@@ -959,35 +980,13 @@ public class LoadAction extends RestBaseController {
      */
     private RedirectView redirectToStreamLoadForward(HttpServletRequest request, TNetworkAddress addr,
             String forwardTarget) {
-        URI urlObj = null;
-        URI resultUriObj = null;
-        String urlStr = request.getRequestURI();
-        String userInfo = null;
-        String modifiedPath = null;
-
-        if (!Strings.isNullOrEmpty(request.getHeader("Authorization"))) {
-            ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
-            userInfo = ClusterNamespace.getNameFromFullName(authInfo.fullUserName)
-                    + ":" + authInfo.password;
-        }
-        try {
-            urlObj = new URI(urlStr);
-            // Replace _stream_load with _stream_load_forward in the path
-            modifiedPath = urlObj.getPath().replace("/_stream_load", "/_stream_load_forward");
-            resultUriObj = new URI("http", userInfo, addr.getHostname(),
-                    addr.getPort(), modifiedPath, "", null);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        String redirectUrl = resultUriObj.toASCIIString();
-
-        // Add forward_to parameter (note: toASCIIString() already includes '?' due to empty query)
+        String modifiedPath = request.getRequestURI().replace("/_stream_load", "/_stream_load_forward");
         String queryString = request.getQueryString();
+        String redirectQuery = "forward_to=" + forwardTarget;
         if (!Strings.isNullOrEmpty(queryString)) {
-            redirectUrl += queryString + "&forward_to=" + forwardTarget;
-        } else {
-            redirectUrl += "forward_to=" + forwardTarget;
+            redirectQuery = queryString + "&" + redirectQuery;
         }
+        String redirectUrl = buildRedirectUrl(request, addr, modifiedPath, redirectQuery);
 
         LOG.info("Redirect stream load forward url: {}, forward_to: {}",
                 "http://" + addr.getHostname() + ":" + addr.getPort() + modifiedPath, forwardTarget);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -731,6 +731,13 @@ public class LoadAction extends RestBaseController {
     private void drainStreamLoadRequestBodyAfterRedirect(HttpServletRequest request, String redirectTarget,
             String dbName, String tableName, String label) {
         long drainLimit = Config.stream_load_redirect_bounded_drain_max_bytes;
+        if (!shouldDrainRequestBodyAfterRedirect(request, drainLimit)) {
+            LOG.info("skip bounded drain after stream load redirect, target: {}, db: {}, tbl: {}, label: {},"
+                            + " max_drain_bytes: {}, content_length: {}, transfer_encoding: {}",
+                    redirectTarget, dbName, tableName, label, drainLimit, request.getContentLengthLong(),
+                    request.getHeader("Transfer-Encoding"));
+            return;
+        }
         LOG.info("write stream load redirect and start bounded drain, target: {}, db: {}, tbl: {}, label: {},"
                         + " max_drain_bytes: {}",
                 redirectTarget, dbName, tableName, label, drainLimit);
@@ -740,6 +747,21 @@ public class LoadAction extends RestBaseController {
                         + " drained_bytes: {}, elapsed_ms: {}, exit_reason: {}",
                 redirectTarget, dbName, tableName, label, drainResult.getDrainedBytes(),
                 drainResult.getElapsedMillis(), drainResult.getExitReason());
+    }
+
+    private boolean shouldDrainRequestBodyAfterRedirect(HttpServletRequest request, long drainLimit) {
+        long contentLength = request.getContentLengthLong();
+        if (contentLength == 0) {
+            return false;
+        }
+        if (contentLength > drainLimit) {
+            return false;
+        }
+        String transferEncoding = request.getHeader("Transfer-Encoding");
+        if (contentLength < 0 && Strings.isNullOrEmpty(transferEncoding)) {
+            return false;
+        }
+        return true;
     }
 
     private Backend selectBackendForGroupCommit(String clusterName, HttpServletRequest req, long tableId)

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -751,14 +751,11 @@ public class LoadAction extends RestBaseController {
 
     private boolean shouldDrainRequestBodyAfterRedirect(HttpServletRequest request, long drainLimit) {
         long contentLength = request.getContentLengthLong();
-        if (contentLength == 0) {
-            return false;
-        }
         if (contentLength > drainLimit) {
             return false;
         }
         String transferEncoding = request.getHeader("Transfer-Encoding");
-        if (contentLength < 0 && Strings.isNullOrEmpty(transferEncoding)) {
+        if (contentLength <= 0 && Strings.isNullOrEmpty(transferEncoding)) {
             return false;
         }
         return true;

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -44,7 +44,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URI;
 import java.net.URISyntaxException;
 
 public class RestBaseController extends BaseController {
@@ -73,10 +72,13 @@ public class RestBaseController extends BaseController {
         return authInfo;
     }
 
-    public RedirectView redirectTo(HttpServletRequest request, TNetworkAddress addr) {
-        URI urlObj = null;
+    protected String buildRedirectUrl(HttpServletRequest request, TNetworkAddress addr) {
+        return buildRedirectUrl(request, addr, request.getRequestURI(), request.getQueryString());
+    }
+
+    protected String buildRedirectUrl(HttpServletRequest request, TNetworkAddress addr, String requestPath,
+            String queryString) {
         URI resultUriObj = null;
-        String urlStr = request.getRequestURI();
         String userInfo = null;
         if (!Strings.isNullOrEmpty(request.getHeader("Authorization"))) {
             ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
@@ -84,18 +86,29 @@ public class RestBaseController extends BaseController {
                     + ":" + authInfo.password;
         }
         try {
-            urlObj = new URI(urlStr);
             resultUriObj = new URI("http", userInfo, addr.getHostname(),
-                    addr.getPort(), urlObj.getPath(), "", null);
+                    addr.getPort(), requestPath, null, null);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
         String redirectUrl = resultUriObj.toASCIIString();
-        if (!Strings.isNullOrEmpty(request.getQueryString())) {
-            redirectUrl += request.getQueryString();
+        if (!Strings.isNullOrEmpty(queryString)) {
+            redirectUrl += "?" + queryString;
         }
         LOG.info("Redirect url: {}", "http://" + addr.getHostname() + ":"
-                    + addr.getPort() + urlObj.getPath());
+                + addr.getPort() + requestPath);
+        return redirectUrl;
+    }
+
+    protected void writeTemporaryRedirect(HttpServletResponse response, String redirectUrl) throws IOException {
+        response.setContentType("text/html;charset=utf-8");
+        response.setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+        response.setHeader("Location", redirectUrl);
+        response.flushBuffer();
+    }
+
+    public RedirectView redirectTo(HttpServletRequest request, TNetworkAddress addr) {
+        String redirectUrl = buildRedirectUrl(request, addr);
         RedirectView redirectView = new RedirectView(redirectUrl);
         redirectView.setContentType("text/html;charset=utf-8");
         redirectView.setStatusCode(org.springframework.http.HttpStatus.TEMPORARY_REDIRECT);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 
 public class RestBaseController extends BaseController {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -79,7 +79,6 @@ public class RestBaseController extends BaseController {
 
     protected String buildRedirectUrl(HttpServletRequest request, TNetworkAddress addr, String requestPath,
             String queryString) {
-        URI resultUriObj = null;
         String userInfo = null;
         if (!Strings.isNullOrEmpty(request.getHeader("Authorization"))) {
             ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
@@ -87,18 +86,19 @@ public class RestBaseController extends BaseController {
                     + ":" + authInfo.password;
         }
         try {
-            resultUriObj = new URI("http", userInfo, addr.getHostname(),
-                    addr.getPort(), requestPath, null, null);
+            // Preserve the original request path to avoid re-encoding an already encoded URI path.
+            URI authorityUri = new URI("http", userInfo, addr.getHostname(),
+                    addr.getPort(), null, null, null);
+            String redirectUrl = authorityUri.toASCIIString() + requestPath;
+            if (!Strings.isNullOrEmpty(queryString)) {
+                redirectUrl += "?" + queryString;
+            }
+            LOG.info("Redirect url: {}", "http://" + addr.getHostname() + ":"
+                    + addr.getPort() + requestPath);
+            return redirectUrl;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        String redirectUrl = resultUriObj.toASCIIString();
-        if (!Strings.isNullOrEmpty(queryString)) {
-            redirectUrl += "?" + queryString;
-        }
-        LOG.info("Redirect url: {}", "http://" + addr.getHostname() + ":"
-                + addr.getPort() + requestPath);
-        return redirectUrl;
     }
 
     protected void writeTemporaryRedirect(HttpServletResponse response, String redirectUrl) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtil.java
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.util;
+
+import com.google.common.base.Preconditions;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+
+public final class StreamLoadRedirectDrainUtil {
+    private static final Logger LOG = LogManager.getLogger(StreamLoadRedirectDrainUtil.class);
+
+    private static final int BUFFER_SIZE = 8 * 1024;
+    private static final int IDLE_SLEEP_MS = 5;
+    private static final int MAX_IDLE_LOOPS = 3;
+
+    private StreamLoadRedirectDrainUtil() {
+    }
+
+    public static DrainResult drainRequestBodyAfterRedirect(HttpServletRequest request, long maxBytes) {
+        try {
+            return drainRequestBodyAfterRedirect(request.getInputStream(), maxBytes);
+        } catch (IOException e) {
+            LOG.warn("failed to get request input stream for stream load redirect drain", e);
+            return new DrainResult(0, 0, ExitReason.ERROR);
+        }
+    }
+
+    static DrainResult drainRequestBodyAfterRedirect(ServletInputStream inputStream, long maxBytes) {
+        Preconditions.checkArgument(maxBytes > 0, "maxBytes must be positive");
+
+        long startNanos = System.nanoTime();
+        long drainedBytes = 0;
+        int idleLoops = 0;
+        byte[] buffer = new byte[(int) Math.min(BUFFER_SIZE, maxBytes)];
+
+        try {
+            while (drainedBytes < maxBytes) {
+                int availableBytes = inputStream.available();
+                if (availableBytes <= 0) {
+                    idleLoops++;
+                    if (idleLoops >= MAX_IDLE_LOOPS) {
+                        return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.IDLE_TIMEOUT);
+                    }
+                    if (!sleepForIdleWindow()) {
+                        return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.ERROR);
+                    }
+                    continue;
+                }
+
+                idleLoops = 0;
+                int readLimit = (int) Math.min(Math.min(maxBytes - drainedBytes, buffer.length), availableBytes);
+                int readBytes = inputStream.read(buffer, 0, readLimit);
+                if (readBytes < 0) {
+                    return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.EOF);
+                }
+                if (readBytes == 0) {
+                    continue;
+                }
+                drainedBytes += readBytes;
+            }
+            return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.MAX_BYTES);
+        } catch (IOException e) {
+            LOG.warn("failed while draining request body after stream load redirect", e);
+            return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.ERROR);
+        }
+    }
+
+    private static boolean sleepForIdleWindow() {
+        try {
+            Thread.sleep(IDLE_SLEEP_MS);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    private static long elapsedMillis(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
+    }
+
+    public enum ExitReason {
+        EOF,
+        MAX_BYTES,
+        IDLE_TIMEOUT,
+        ERROR
+    }
+
+    public static final class DrainResult {
+        private final long drainedBytes;
+        private final long elapsedMillis;
+        private final ExitReason exitReason;
+
+        public DrainResult(long drainedBytes, long elapsedMillis, ExitReason exitReason) {
+            this.drainedBytes = drainedBytes;
+            this.elapsedMillis = elapsedMillis;
+            this.exitReason = exitReason;
+        }
+
+        public long getDrainedBytes() {
+            return drainedBytes;
+        }
+
+        public long getElapsedMillis() {
+            return elapsedMillis;
+        }
+
+        public ExitReason getExitReason() {
+            return exitReason;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtil.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.httpv2.util;
 
+import org.apache.doris.common.Config;
+
 import com.google.common.base.Preconditions;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,7 +32,6 @@ public final class StreamLoadRedirectDrainUtil {
 
     private static final int BUFFER_SIZE = 8 * 1024;
     private static final int IDLE_SLEEP_MS = 5;
-    private static final int MAX_IDLE_TIME_MS = 100;
 
     private StreamLoadRedirectDrainUtil() {
     }
@@ -62,11 +63,9 @@ public final class StreamLoadRedirectDrainUtil {
                 if (availableBytes <= 0) {
                     // Allow a bounded idle window so slow clients can still deliver buffered bytes.
                     idleStartNanos = idleStartNanos < 0 ? System.nanoTime() : idleStartNanos;
-                    if (elapsedMillis(idleStartNanos) >= MAX_IDLE_TIME_MS) {
-                        return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.IDLE_TIMEOUT);
-                    }
-                    if (!sleepForIdleWindow()) {
-                        return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.ERROR);
+                    DrainResult idleWaitResult = waitForMoreDataOrExit(idleStartNanos, drainedBytes, startNanos);
+                    if (idleWaitResult != null) {
+                        return idleWaitResult;
                     }
                     continue;
                 }
@@ -80,11 +79,9 @@ public final class StreamLoadRedirectDrainUtil {
                 if (readBytes == 0) {
                     // Treat zero-byte reads as transient backpressure instead of busy-spinning.
                     idleStartNanos = idleStartNanos < 0 ? System.nanoTime() : idleStartNanos;
-                    if (elapsedMillis(idleStartNanos) >= MAX_IDLE_TIME_MS) {
-                        return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.IDLE_TIMEOUT);
-                    }
-                    if (!sleepForIdleWindow()) {
-                        return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.ERROR);
+                    DrainResult idleWaitResult = waitForMoreDataOrExit(idleStartNanos, drainedBytes, startNanos);
+                    if (idleWaitResult != null) {
+                        return idleWaitResult;
                     }
                     continue;
                 }
@@ -97,11 +94,23 @@ public final class StreamLoadRedirectDrainUtil {
         }
     }
 
+    // Convert a bounded idle wait into a terminal drain result when the grace window expires or gets interrupted.
+    private static DrainResult waitForMoreDataOrExit(long idleStartNanos, long drainedBytes, long startNanos) {
+        if (elapsedMillis(idleStartNanos) >= Config.stream_load_redirect_bounded_drain_max_idle_time_ms) {
+            return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.IDLE_TIMEOUT);
+        }
+        if (!sleepForIdleWindow()) {
+            return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.INTERRUPTED);
+        }
+        return null;
+    }
+
     private static boolean sleepForIdleWindow() {
         try {
             Thread.sleep(IDLE_SLEEP_MS);
             return true;
         } catch (InterruptedException e) {
+            LOG.warn("stream load redirect drain idle wait is interrupted", e);
             Thread.currentThread().interrupt();
             return false;
         }
@@ -115,6 +124,7 @@ public final class StreamLoadRedirectDrainUtil {
         EOF,
         MAX_BYTES,
         IDLE_TIMEOUT,
+        INTERRUPTED,
         ERROR
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtil.java
@@ -30,7 +30,7 @@ public final class StreamLoadRedirectDrainUtil {
 
     private static final int BUFFER_SIZE = 8 * 1024;
     private static final int IDLE_SLEEP_MS = 5;
-    private static final int MAX_IDLE_LOOPS = 3;
+    private static final int MAX_IDLE_TIME_MS = 100;
 
     private StreamLoadRedirectDrainUtil() {
     }
@@ -49,15 +49,20 @@ public final class StreamLoadRedirectDrainUtil {
 
         long startNanos = System.nanoTime();
         long drainedBytes = 0;
-        int idleLoops = 0;
+        long idleStartNanos = -1L;
         byte[] buffer = new byte[(int) Math.min(BUFFER_SIZE, maxBytes)];
 
         try {
             while (drainedBytes < maxBytes) {
+                // Prefer an explicit EOF signal before relying on available() as a readiness hint.
+                if (inputStream.isFinished()) {
+                    return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.EOF);
+                }
                 int availableBytes = inputStream.available();
                 if (availableBytes <= 0) {
-                    idleLoops++;
-                    if (idleLoops >= MAX_IDLE_LOOPS) {
+                    // Allow a bounded idle window so slow clients can still deliver buffered bytes.
+                    idleStartNanos = idleStartNanos < 0 ? System.nanoTime() : idleStartNanos;
+                    if (elapsedMillis(idleStartNanos) >= MAX_IDLE_TIME_MS) {
                         return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.IDLE_TIMEOUT);
                     }
                     if (!sleepForIdleWindow()) {
@@ -66,13 +71,21 @@ public final class StreamLoadRedirectDrainUtil {
                     continue;
                 }
 
-                idleLoops = 0;
+                idleStartNanos = -1L;
                 int readLimit = (int) Math.min(Math.min(maxBytes - drainedBytes, buffer.length), availableBytes);
                 int readBytes = inputStream.read(buffer, 0, readLimit);
                 if (readBytes < 0) {
                     return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.EOF);
                 }
                 if (readBytes == 0) {
+                    // Treat zero-byte reads as transient backpressure instead of busy-spinning.
+                    idleStartNanos = idleStartNanos < 0 ? System.nanoTime() : idleStartNanos;
+                    if (elapsedMillis(idleStartNanos) >= MAX_IDLE_TIME_MS) {
+                        return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.IDLE_TIMEOUT);
+                    }
+                    if (!sleepForIdleWindow()) {
+                        return new DrainResult(drainedBytes, elapsedMillis(startNanos), ExitReason.ERROR);
+                    }
                     continue;
                 }
                 drainedBytes += readBytes;

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
@@ -38,11 +38,13 @@ public class LoadActionTest {
     @AfterEach
     public void tearDown() {
         Config.stream_load_redirect_bounded_drain_max_bytes = 0;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
     }
 
     @Test
     public void testCreateRedirectResponseReturnsRedirectViewWhenBoundedDrainDisabled() throws Exception {
         Config.stream_load_redirect_bounded_drain_max_bytes = 0;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
         LoadAction loadAction = new LoadAction();
         HttpServletRequest request = mockStreamLoadRequest();
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
@@ -59,6 +61,7 @@ public class LoadActionTest {
     @Test
     public void testCreateRedirectResponseWrites307WhenBoundedDrainEnabled() throws Exception {
         Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
         LoadAction loadAction = new LoadAction();
         HttpServletRequest request = mockStreamLoadRequest();
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
@@ -76,6 +79,7 @@ public class LoadActionTest {
     @Test
     public void testCreateRedirectResponseKeepsNonStreamLoadBehavior() throws Exception {
         Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
         LoadAction loadAction = new LoadAction();
         HttpServletRequest request = mockStreamLoadRequest();
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
@@ -37,8 +37,8 @@ public class LoadActionTest {
 
     @AfterEach
     public void tearDown() {
-        Config.stream_load_redirect_bounded_drain_max_bytes = 0;
-        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        Config.stream_load_redirect_bounded_drain_max_bytes = 1024L * 1024 * 1024;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 1000;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.rest;
+
+import org.apache.doris.common.Config;
+import org.apache.doris.thrift.TNetworkAddress;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.view.RedirectView;
+
+import java.lang.reflect.Method;
+
+public class LoadActionTest {
+
+    @AfterEach
+    public void tearDown() {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 0;
+    }
+
+    @Test
+    public void testCreateRedirectResponseReturnsRedirectViewWhenBoundedDrainDisabled() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 0;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest();
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), true, "db1", "tbl1", "label1");
+
+        Assertions.assertTrue(result instanceof RedirectView);
+        RedirectView redirectView = (RedirectView) result;
+        Assertions.assertEquals("http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar", redirectView.getUrl());
+        Assertions.assertEquals(HttpStatus.TEMPORARY_REDIRECT, redirectView.getStatusCode());
+        Mockito.verifyNoInteractions(response);
+    }
+
+    @Test
+    public void testCreateRedirectResponseWrites307WhenBoundedDrainEnabled() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest();
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), true, "db1", "tbl1", "label1");
+
+        Assertions.assertNull(result);
+        Mockito.verify(response).setContentType("text/html;charset=utf-8");
+        Mockito.verify(response).setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+        Mockito.verify(response).setHeader("Location", "http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar");
+        Mockito.verify(response).flushBuffer();
+    }
+
+    @Test
+    public void testCreateRedirectResponseKeepsNonStreamLoadBehavior() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest();
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), false, "db1", "tbl1", "label1");
+
+        Assertions.assertTrue(result instanceof RedirectView);
+        Mockito.verifyNoInteractions(response);
+    }
+
+    private Object invokeCreateRedirectResponse(LoadAction loadAction, HttpServletRequest request,
+            HttpServletResponse response, TNetworkAddress redirectAddr, boolean isStreamLoad, String dbName,
+            String tableName, String label) throws Exception {
+        Method method = LoadAction.class.getDeclaredMethod("createRedirectResponse",
+                HttpServletRequest.class, HttpServletResponse.class, TNetworkAddress.class,
+                boolean.class, String.class, String.class, String.class);
+        method.setAccessible(true);
+        return method.invoke(loadAction, request, response, redirectAddr, isStreamLoad, dbName, tableName, label);
+    }
+
+    private HttpServletRequest mockStreamLoadRequest() throws Exception {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/api/db1/tbl1/_stream_load");
+        Mockito.when(request.getQueryString()).thenReturn("foo=bar");
+        Mockito.when(request.getHeader("Authorization")).thenReturn(null);
+        Mockito.when(request.getInputStream()).thenReturn(new IdleServletInputStream());
+        return request;
+    }
+
+    private static class IdleServletInputStream extends ServletInputStream {
+        @Override
+        public int read() {
+            return -1;
+        }
+
+        @Override
+        public int available() {
+            return 0;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return false;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
@@ -53,7 +53,6 @@ public class LoadActionTest {
         Assertions.assertTrue(result instanceof RedirectView);
         RedirectView redirectView = (RedirectView) result;
         Assertions.assertEquals("http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar", redirectView.getUrl());
-        Assertions.assertEquals(HttpStatus.TEMPORARY_REDIRECT, redirectView.getStatusCode());
         Mockito.verifyNoInteractions(response);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
@@ -61,9 +61,9 @@ public class LoadActionTest {
     @Test
     public void testCreateRedirectResponseWrites307WhenBoundedDrainEnabled() throws Exception {
         Config.stream_load_redirect_bounded_drain_max_bytes = 8;
-        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;
         LoadAction loadAction = new LoadAction();
-        HttpServletRequest request = mockStreamLoadRequest();
+        HttpServletRequest request = mockStreamLoadRequest(-1, "chunked", true);
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
 
         Object result = invokeCreateRedirectResponse(loadAction, request, response,
@@ -74,6 +74,64 @@ public class LoadActionTest {
         Mockito.verify(response).setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
         Mockito.verify(response).setHeader("Location", "http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar");
         Mockito.verify(response).flushBuffer();
+        Mockito.verify(request).getInputStream();
+    }
+
+    @Test
+    public void testCreateRedirectResponseSkipsDrainWithoutRequestBody() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest(-1, null, false);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), true, "db1", "tbl1", "label1");
+
+        Assertions.assertNull(result);
+        Mockito.verify(response).setContentType("text/html;charset=utf-8");
+        Mockito.verify(response).setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+        Mockito.verify(response).setHeader("Location", "http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar");
+        Mockito.verify(response).flushBuffer();
+        Mockito.verify(request, Mockito.never()).getInputStream();
+    }
+
+    @Test
+    public void testCreateRedirectResponseSkipsDrainWhenContentLengthIsZero() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest(0, null, false);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), true, "db1", "tbl1", "label1");
+
+        Assertions.assertNull(result);
+        Mockito.verify(response).setContentType("text/html;charset=utf-8");
+        Mockito.verify(response).setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+        Mockito.verify(response).setHeader("Location", "http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar");
+        Mockito.verify(response).flushBuffer();
+        Mockito.verify(request, Mockito.never()).getInputStream();
+    }
+
+    @Test
+    public void testCreateRedirectResponseSkipsDrainWhenContentLengthExceedsLimit() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest(16, null, false);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), true, "db1", "tbl1", "label1");
+
+        Assertions.assertNull(result);
+        Mockito.verify(response).setContentType("text/html;charset=utf-8");
+        Mockito.verify(response).setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+        Mockito.verify(response).setHeader("Location", "http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar");
+        Mockito.verify(response).flushBuffer();
+        Mockito.verify(request, Mockito.never()).getInputStream();
     }
 
     @Test
@@ -102,11 +160,20 @@ public class LoadActionTest {
     }
 
     private HttpServletRequest mockStreamLoadRequest() throws Exception {
+        return mockStreamLoadRequest(-1, null, true);
+    }
+
+    private HttpServletRequest mockStreamLoadRequest(long contentLength, String transferEncoding,
+            boolean stubInputStream) throws Exception {
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         Mockito.when(request.getRequestURI()).thenReturn("/api/db1/tbl1/_stream_load");
         Mockito.when(request.getQueryString()).thenReturn("foo=bar");
         Mockito.when(request.getHeader("Authorization")).thenReturn(null);
-        Mockito.when(request.getInputStream()).thenReturn(new IdleServletInputStream());
+        Mockito.when(request.getContentLengthLong()).thenReturn(contentLength);
+        Mockito.when(request.getHeader("Transfer-Encoding")).thenReturn(transferEncoding);
+        if (stubInputStream) {
+            Mockito.when(request.getInputStream()).thenReturn(new IdleServletInputStream());
+        }
         return request;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
@@ -116,6 +116,23 @@ public class LoadActionTest {
     }
 
     @Test
+    public void testCreateRedirectResponseDrainsWhenContentLengthIsZeroButChunked() throws Exception {
+        Config.stream_load_redirect_bounded_drain_max_bytes = 8;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;
+        LoadAction loadAction = new LoadAction();
+        HttpServletRequest request = mockStreamLoadRequest(0, "chunked", true);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        Object result = invokeCreateRedirectResponse(loadAction, request, response,
+                new TNetworkAddress("be-host", 8040), true, "db1", "tbl1", "label1");
+
+        Assertions.assertNull(result);
+        Mockito.verify(response).setHeader("Location", "http://be-host:8040/api/db1/tbl1/_stream_load?foo=bar");
+        Mockito.verify(response).flushBuffer();
+        Mockito.verify(request).getInputStream();
+    }
+
+    @Test
     public void testCreateRedirectResponseSkipsDrainWhenContentLengthExceedsLimit() throws Exception {
         Config.stream_load_redirect_bounded_drain_max_bytes = 8;
         Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
@@ -37,7 +37,7 @@ public class LoadActionTest {
 
     @AfterEach
     public void tearDown() {
-        Config.stream_load_redirect_bounded_drain_max_bytes = 1024L * 1024 * 1024;
+        Config.stream_load_redirect_bounded_drain_max_bytes = 2L * 1024 * 1024 * 1024;
         Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 1000;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/RestBaseControllerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/RestBaseControllerTest.java
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.rest;
+
+import org.apache.doris.thrift.TNetworkAddress;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class RestBaseControllerTest {
+
+    @Test
+    public void testBuildRedirectUrlPreservesEncodedPath() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getHeader("Authorization")).thenReturn(null);
+
+        TestRestController controller = new TestRestController();
+        String redirectUrl = controller.buildRedirectUrlForTest(request,
+                new TNetworkAddress("be-host", 8040), "/api/db%2Ftbl/_stream_load", "k=a%2Bb");
+
+        Assert.assertEquals("http://be-host:8040/api/db%2Ftbl/_stream_load?k=a%2Bb", redirectUrl);
+    }
+
+    @Test
+    public void testBuildRedirectUrlWithoutQueryString() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getHeader("Authorization")).thenReturn(null);
+
+        TestRestController controller = new TestRestController();
+        String redirectUrl = controller.buildRedirectUrlForTest(request,
+                new TNetworkAddress("be-host", 8040), "/api/db%2Ftbl/_stream_load", null);
+
+        Assert.assertEquals("http://be-host:8040/api/db%2Ftbl/_stream_load", redirectUrl);
+    }
+
+    private static class TestRestController extends RestBaseController {
+        private String buildRedirectUrlForTest(HttpServletRequest request, TNetworkAddress addr,
+                String requestPath, String queryString) {
+            return buildRedirectUrl(request, addr, requestPath, queryString);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtilTest.java
@@ -35,7 +35,18 @@ public class StreamLoadRedirectDrainUtilTest {
                         new QueueAvailableServletInputStream("hello".getBytes(), 5, 0, 0, 0), 16);
 
         Assertions.assertEquals(5, drainResult.getDrainedBytes());
-        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.IDLE_TIMEOUT, drainResult.getExitReason());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.EOF, drainResult.getExitReason());
+    }
+
+    @Test
+    // Verify delayed body chunks are still drained when they arrive within the bounded idle window.
+    public void testDrainRequestBodyAllowsDelayedArrivalWithinIdleWindow() {
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
+                        new QueueAvailableServletInputStream("hello".getBytes(), 0, 0, 0, 0, 0, 5), 16);
+
+        Assertions.assertEquals(5, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.EOF, drainResult.getExitReason());
     }
 
     @Test
@@ -51,8 +62,7 @@ public class StreamLoadRedirectDrainUtilTest {
     @Test
     public void testDrainRequestBodyIdleTimeout() {
         StreamLoadRedirectDrainUtil.DrainResult drainResult =
-                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
-                        new QueueAvailableServletInputStream(new byte[0], 0, 0, 0, 0), 8);
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(new NeverReadyServletInputStream(), 8);
 
         Assertions.assertEquals(0, drainResult.getDrainedBytes());
         Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.IDLE_TIMEOUT, drainResult.getExitReason());
@@ -180,6 +190,33 @@ public class StreamLoadRedirectDrainUtilTest {
         @Override
         public boolean isFinished() {
             return true;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+    }
+
+    // Keep reporting no readable bytes without reaching EOF to simulate a stalled client.
+    private static class NeverReadyServletInputStream extends ServletInputStream {
+        @Override
+        public int read() {
+            return -1;
+        }
+
+        @Override
+        public int available() {
+            return 0;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return false;
         }
 
         @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtilTest.java
@@ -17,8 +17,11 @@
 
 package org.apache.doris.httpv2.util;
 
+import org.apache.doris.common.Config;
+
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletInputStream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -28,8 +31,14 @@ import java.util.Queue;
 
 public class StreamLoadRedirectDrainUtilTest {
 
+    @AfterEach
+    public void tearDown() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+    }
+
     @Test
     public void testDrainRequestBodyWithinMaxBytes() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
         StreamLoadRedirectDrainUtil.DrainResult drainResult =
                 StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
                         new QueueAvailableServletInputStream("hello".getBytes(), 5, 0, 0, 0), 16);
@@ -41,6 +50,7 @@ public class StreamLoadRedirectDrainUtilTest {
     @Test
     // Verify delayed body chunks are still drained when they arrive within the bounded idle window.
     public void testDrainRequestBodyAllowsDelayedArrivalWithinIdleWindow() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
         StreamLoadRedirectDrainUtil.DrainResult drainResult =
                 StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
                         new QueueAvailableServletInputStream("hello".getBytes(), 0, 0, 0, 0, 0, 5), 16);
@@ -51,6 +61,7 @@ public class StreamLoadRedirectDrainUtilTest {
 
     @Test
     public void testDrainRequestBodyStopsAtMaxBytes() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
         StreamLoadRedirectDrainUtil.DrainResult drainResult =
                 StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
                         new QueueAvailableServletInputStream("hello world".getBytes(), 11), 5);
@@ -61,6 +72,7 @@ public class StreamLoadRedirectDrainUtilTest {
 
     @Test
     public void testDrainRequestBodyIdleTimeout() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
         StreamLoadRedirectDrainUtil.DrainResult drainResult =
                 StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(new NeverReadyServletInputStream(), 8);
 
@@ -69,7 +81,36 @@ public class StreamLoadRedirectDrainUtilTest {
     }
 
     @Test
+    public void testDrainRequestBodyUsesConfiguredIdleTime() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 0;
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
+                        new QueueAvailableServletInputStream("hello".getBytes(), 0, 5), 16);
+
+        Assertions.assertEquals(0, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.IDLE_TIMEOUT, drainResult.getExitReason());
+    }
+
+    @Test
+    public void testDrainRequestBodyInterruptedWhileWaitingForMoreData() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        try {
+            Thread.currentThread().interrupt();
+            StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                    StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(new NeverReadyServletInputStream(), 8);
+
+            Assertions.assertEquals(0, drainResult.getDrainedBytes());
+            Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.INTERRUPTED,
+                    drainResult.getExitReason());
+        } finally {
+            // Clear the interrupt flag to avoid affecting later tests in the same thread.
+            Thread.interrupted();
+        }
+    }
+
+    @Test
     public void testDrainRequestBodyReadError() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
         StreamLoadRedirectDrainUtil.DrainResult drainResult =
                 StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(new ErrorServletInputStream(), 8);
 
@@ -79,6 +120,7 @@ public class StreamLoadRedirectDrainUtilTest {
 
     @Test
     public void testDrainRequestBodyEof() {
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
         StreamLoadRedirectDrainUtil.DrainResult drainResult =
                 StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(new EofServletInputStream(), 8);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtilTest.java
@@ -1,0 +1,194 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.util;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public class StreamLoadRedirectDrainUtilTest {
+
+    @Test
+    public void testDrainRequestBodyWithinMaxBytes() {
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
+                        new QueueAvailableServletInputStream("hello".getBytes(), 5, 0, 0, 0), 16);
+
+        Assertions.assertEquals(5, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.IDLE_TIMEOUT, drainResult.getExitReason());
+    }
+
+    @Test
+    public void testDrainRequestBodyStopsAtMaxBytes() {
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
+                        new QueueAvailableServletInputStream("hello world".getBytes(), 11), 5);
+
+        Assertions.assertEquals(5, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.MAX_BYTES, drainResult.getExitReason());
+    }
+
+    @Test
+    public void testDrainRequestBodyIdleTimeout() {
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(
+                        new QueueAvailableServletInputStream(new byte[0], 0, 0, 0, 0), 8);
+
+        Assertions.assertEquals(0, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.IDLE_TIMEOUT, drainResult.getExitReason());
+    }
+
+    @Test
+    public void testDrainRequestBodyReadError() {
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(new ErrorServletInputStream(), 8);
+
+        Assertions.assertEquals(0, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.ERROR, drainResult.getExitReason());
+    }
+
+    @Test
+    public void testDrainRequestBodyEof() {
+        StreamLoadRedirectDrainUtil.DrainResult drainResult =
+                StreamLoadRedirectDrainUtil.drainRequestBodyAfterRedirect(new EofServletInputStream(), 8);
+
+        Assertions.assertEquals(0, drainResult.getDrainedBytes());
+        Assertions.assertEquals(StreamLoadRedirectDrainUtil.ExitReason.EOF, drainResult.getExitReason());
+    }
+
+    private static class QueueAvailableServletInputStream extends ServletInputStream {
+        private final byte[] data;
+        private final Queue<Integer> availableValues = new ArrayDeque<>();
+        private int offset = 0;
+
+        QueueAvailableServletInputStream(byte[] data, int... availableValues) {
+            this.data = data;
+            for (int availableValue : availableValues) {
+                this.availableValues.add(availableValue);
+            }
+        }
+
+        @Override
+        public int read() {
+            if (offset >= data.length) {
+                return -1;
+            }
+            return data[offset++] & 0xFF;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) {
+            if (offset >= data.length) {
+                return -1;
+            }
+            int readBytes = Math.min(len, data.length - offset);
+            System.arraycopy(data, offset, b, off, readBytes);
+            offset += readBytes;
+            return readBytes;
+        }
+
+        @Override
+        public int available() {
+            if (!availableValues.isEmpty()) {
+                return availableValues.poll();
+            }
+            return Math.max(0, data.length - offset);
+        }
+
+        @Override
+        public boolean isFinished() {
+            return offset >= data.length;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+    }
+
+    private static class ErrorServletInputStream extends ServletInputStream {
+        @Override
+        public int read() throws IOException {
+            throw new IOException("read error");
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            throw new IOException("read error");
+        }
+
+        @Override
+        public int available() {
+            return 1;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return false;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+    }
+
+    private static class EofServletInputStream extends ServletInputStream {
+        @Override
+        public int read() {
+            return -1;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) {
+            return -1;
+        }
+
+        @Override
+        public int available() {
+            return 1;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return true;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/util/StreamLoadRedirectDrainUtilTest.java
@@ -33,7 +33,7 @@ public class StreamLoadRedirectDrainUtilTest {
 
     @AfterEach
     public void tearDown() {
-        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 100;
+        Config.stream_load_redirect_bounded_drain_max_idle_time_ms = 1000;
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63325

Problem Summary:

**Problem**
- Starting from Doris `3.1.3`, FE uses `Jetty 12`, and this introduced a compatibility change in the Stream Load redirect path.
- When a Stream Load request is sent to FE, FE may return `307 Temporary Redirect` before the request body is fully consumed. Under `Jetty 12`, this behavior is more likely to cause early connection close or reset while the client is still writing the request body.
- As a result, some `HTTP/1.1` streaming clients may observe errors such as `BrokenPipeError` or `ConnectionResetError` when sending Stream Load requests through FE.
- The problem is more visible with chunked uploads, higher network latency, and clients that continue sending request body data before fully processing the redirect response.
- In short, this is a compatibility regression introduced by the `Jetty 12` upgrade in Doris `3.1.3` and later.

**Fix**
- We keep the existing FE-to-BE redirect architecture unchanged, so FE still redirects Stream Load requests to BE instead of proxying the full request body.
- We add a bounded request-body drain step on the FE Stream Load redirect path:
  - FE first writes the `307 Temporary Redirect` response.
  - FE then drains and discards only a bounded amount of the remaining request body.
  - This provides a small compatibility window for in-flight client writes and reduces the chance of early connection reset.
- To make the compatibility path effective out of the box, this PR also enables the bounded drain path by default with a `2GB` drain limit and a `1000ms` idle wait window.

**New Configurations**
- `stream_load_redirect_bounded_drain_max_bytes`
  - Controls the maximum number of request body bytes FE drains after returning `307` for a Stream Load redirect.
  - `0` disables this compatibility logic.
  - A positive value enables bounded draining and limits how much data FE will discard.
  - Default value in this PR: `2GB`.

- `stream_load_redirect_bounded_drain_max_idle_time_ms`
  - Controls how long FE waits for more readable request body data during the bounded drain process.
  - `0` disables the extra idle wait.
  - A positive value provides a small grace window for slow clients or delayed body chunks, helping absorb in-flight writes without keeping the connection open indefinitely.
  - Default value in this PR: `1000ms`.

**Test Result / Validation**
- Verified the behavior with the same Python `HTTP/1.1` chunked Stream Load reproduction used during issue analysis.
- Reproduced requests were sent to FE with `Expect: 100-continue`, `Transfer-Encoding: chunked`, and paced body streaming to maximize the redirect race window.
- Baseline validation on Doris `3.0` (`9030` / FE `8030`):
  - `payload_mb=1`, `chunk_kb=1`, `sleep_ms=0`
  - `payload_mb=8`, `chunk_kb=16`, `sleep_ms=10`
  - Both requests returned normal `307 Temporary Redirect`.
- Validation on the fixed Doris `3.1.4` instance (`9034` / FE `8034`):
  - Before enabling the bounded drain config, the same reproduction still triggered `BrokenPipeError`.
  - After enabling the FE configs below:
    - `stream_load_redirect_bounded_drain_max_bytes = 16777216`
    - `stream_load_redirect_bounded_drain_max_idle_time_ms = 1000`
  - The same two reproduction requests both returned normal `307 Temporary Redirect`.
  - No `BrokenPipeError` or `ConnectionResetError` was observed after the config took effect.
- The PR now further updates the default bounded drain byte limit from `16MB` to `2GB`, while keeping the default idle wait at `1000ms`, so the compatibility path is enabled by default with a more generous drain window.

**Performance Validation**
- I compared FE redirect response time between the Doris `3.0` baseline instance (`9030`) and the fixed Doris `3.1.4` instance (`9034`).
- The goal was to check whether the additional bounded drain logic on FE introduces a noticeable regression compared with the original Jetty 9 behavior.

**Test Setup**
- Reproduction tool: `tools/stream_load_redirect_repro.py`
- Target: FE endpoint on both instances
- Client mode: `httpclient`
- Common parameters:
  - `chunk_kb = 16`
  - `sleep_ms = 0`
- Payload sizes:
  - `32MB`
  - `128MB`
  - `512MB`
- Each case was executed `3` times on each instance, and the average `elapsed_seconds` was used for comparison.

**Results**
- `32MB`
  - `9030`: `9.515s / 12.032s / 9.727s`
  - Average: `10.425s`
  - `9034`: `10.695s / 10.847s / 8.763s`
  - Average: `10.102s`
  - Difference: `9034` was `0.323s` faster, about `3.1%`

- `128MB`
  - `9030`: `37.174s / 34.111s / 37.090s`
  - Average: `36.125s`
  - `9034`: `38.910s / 36.423s / 38.337s`
  - Average: `37.890s`
  - Difference: `9034` was `1.765s` slower, about `4.9%`

- `512MB`
  - `9030`: `157.181s / 161.148s / 174.421s`
  - Average: `164.250s`
  - `9034`: `172.310s / 176.692s / 160.068s`
  - Average: `169.690s`
  - Difference: `9034` was `5.440s` slower, about `3.3%`

**Conclusion**
- Across all tested payload sizes, the difference between `9030` and `9034` stayed within a small range, roughly `-3%` to `+5%`.
- Based on these measurements, the FE bounded drain logic does not show a significant performance regression compared with the baseline FE redirect behavior.
- In other words, the fix improves redirect compatibility while keeping FE redirect response time at a similar level in normal request sizes.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. FE now drains a bounded amount of request body after Stream Load redirect by default, and the default drain byte limit is set to `1GB`.

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->


