### PR TITLE
[improvement] Add session control for external table DML return status

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutor.java
@@ -32,6 +32,7 @@ import org.apache.doris.planner.DataSink;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState;
+import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.transaction.TransactionManager;
 import org.apache.doris.transaction.TransactionStatus;
@@ -109,12 +110,15 @@ public abstract class BaseExternalTableInsertExecutor extends AbstractInsertExec
                 transactionManager.commit(txnId);
             }
             summaryProfile.ifPresent(SummaryProfile::setTransactionEndTime);
-            txnStatus = TransactionStatus.COMMITTED;
             Env.getCurrentEnv().getRefreshManager().handleRefreshTable(
                     catalogName,
                     table.getDatabase().getFullName(),
                     table.getName(),
                     true);
+            // Reporting VISIBLE here only changes the success status returned to the client.
+            // If the DML and the follow-up query may hit different non-master FEs, enableStrongConsistencyRead
+            // is still required to strengthen read-after-write consistency.
+            txnStatus = getExternalTableDmlReturnStatus(ctx.getSessionVariable());
         }
     }
 
@@ -174,5 +178,11 @@ public abstract class BaseExternalTableInsertExecutor extends AbstractInsertExec
                 txnStatus, loadedRows, 0);
         // update it, so that user can get loaded rows in fe.audit.log
         ctx.updateReturnRows((int) loadedRows);
+    }
+
+    static TransactionStatus getExternalTableDmlReturnStatus(SessionVariable sessionVariable) {
+        return sessionVariable.isExternalTableDmlReturnVisible()
+                ? TransactionStatus.VISIBLE
+                : TransactionStatus.COMMITTED;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -506,6 +506,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_STRONG_CONSISTENCY = "enable_strong_consistency_read";
 
+    public static final String EXTERNAL_TABLE_DML_RETURN_STATUS = "external_table_dml_return_status";
+    public static final String EXTERNAL_TABLE_DML_RETURN_STATUS_VISIBLE = "visible";
+    public static final String EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED = "committed";
+
     public static final String GROUP_COMMIT = "group_commit";
 
     public static final String ENABLE_PREPARED_STMT_AUDIT_LOG = "enable_prepared_stmt_audit_log";
@@ -1966,6 +1970,15 @@ public class SessionVariable implements Serializable, Writable {
                     + "real time. If you want strong consistent reads between sessions, set this variable to true. "
     })
     public boolean enableStrongConsistencyRead = false;
+
+    // This session variable only controls how successful external table DML reports status to the client.
+    @VariableMgr.VarAttr(name = EXTERNAL_TABLE_DML_RETURN_STATUS, needForward = true,
+            checker = "checkExternalTableDmlReturnStatus", setter = "setExternalTableDmlReturnStatus",
+            description = {"控制外表 CTAS 与 INSERT INTO SELECT 成功时返回给客户端的状态。",
+                    "Controls the status returned to the client for successful external table CTAS and "
+                            + "INSERT INTO SELECT statements."},
+            options = {EXTERNAL_TABLE_DML_RETURN_STATUS_VISIBLE, EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED})
+    public String externalTableDmlReturnStatus = EXTERNAL_TABLE_DML_RETURN_STATUS_VISIBLE;
 
     @VariableMgr.VarAttr(name = PARALLEL_SYNC_ANALYZE_TASK_NUM)
     public int parallelSyncAnalyzeTaskNum = 2;
@@ -3714,6 +3727,18 @@ public class SessionVariable implements Serializable, Writable {
         this.sqlDialect = sqlDialect == null ? null : sqlDialect.toLowerCase();
     }
 
+    public String getExternalTableDmlReturnStatus() {
+        return externalTableDmlReturnStatus;
+    }
+
+    public boolean isExternalTableDmlReturnVisible() {
+        return EXTERNAL_TABLE_DML_RETURN_STATUS_VISIBLE.equals(externalTableDmlReturnStatus);
+    }
+
+    public void setExternalTableDmlReturnStatus(String externalTableDmlReturnStatus) {
+        this.externalTableDmlReturnStatus = normalizeExternalTableDmlReturnStatus(externalTableDmlReturnStatus);
+    }
+
     /**
      * getInsertVisibleTimeoutMs.
      **/
@@ -4478,6 +4503,8 @@ public class SessionVariable implements Serializable, Writable {
                         throw new IOException("invalid type: " + field.getType().getSimpleName());
                 }
             }
+            // Normalize serialized string enums so forwarded and restored sessions keep the same semantics.
+            externalTableDmlReturnStatus = normalizeExternalTableDmlReturnStatus(externalTableDmlReturnStatus);
         } catch (Exception e) {
             throw new IOException("failed to read session variable: " + e.getMessage());
         }
@@ -4548,6 +4575,8 @@ public class SessionVariable implements Serializable, Writable {
                         throw new IllegalArgumentException("Unknown field type: " + f.getType().getSimpleName());
                 }
             }
+            // Normalize forwarded string enums because forwarded assignments bypass dedicated setters.
+            externalTableDmlReturnStatus = normalizeExternalTableDmlReturnStatus(externalTableDmlReturnStatus);
         } catch (IllegalAccessException e) {
             LOG.error("failed to set forward variables", e);
         }
@@ -4844,11 +4873,31 @@ public class SessionVariable implements Serializable, Writable {
         }
     }
 
+    public void checkExternalTableDmlReturnStatus(String externalTableDmlReturnStatus) {
+        if (StringUtils.isEmpty(externalTableDmlReturnStatus)) {
+            throw new UnsupportedOperationException("externalTableDmlReturnStatus value is empty");
+        }
+        String normalized = normalizeExternalTableDmlReturnStatus(externalTableDmlReturnStatus);
+        if (!EXTERNAL_TABLE_DML_RETURN_STATUS_VISIBLE.equals(normalized)
+                && !EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED.equals(normalized)) {
+            throw new UnsupportedOperationException(
+                    "externalTableDmlReturnStatus value is invalid, the invalid value is "
+                            + externalTableDmlReturnStatus);
+        }
+    }
+
     public void checkBatchSize(String batchSize) {
         Long batchSizeValue = Long.valueOf(batchSize);
         if (batchSizeValue < 1 || batchSizeValue > 65535) {
             throw new InvalidParameterException("batch_size should be between 1 and 65535)");
         }
+    }
+
+    // Normalize the user input so the execution path can compare the configured mode directly.
+    private String normalizeExternalTableDmlReturnStatus(String externalTableDmlReturnStatus) {
+        return externalTableDmlReturnStatus == null
+                ? null
+                : externalTableDmlReturnStatus.toLowerCase(Locale.ROOT);
     }
 
     public boolean isEnableInsertGroupCommit() {
@@ -5075,4 +5124,3 @@ public class SessionVariable implements Serializable, Writable {
         return defaultVariantMaxSparseColumnStatisticsSize;
     }
 }
-

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutorTest.java
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands.insert;
+
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.transaction.TransactionStatus;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for external table DML status selection.
+ */
+public class BaseExternalTableInsertExecutorTest {
+
+    @Test
+    public void testGetExternalTableDmlReturnStatus() {
+        SessionVariable sessionVariable = new SessionVariable();
+        Assertions.assertEquals(TransactionStatus.VISIBLE,
+                BaseExternalTableInsertExecutor.getExternalTableDmlReturnStatus(sessionVariable));
+
+        // External table DML can still report COMMITTED when the session variable requests it.
+        sessionVariable.setExternalTableDmlReturnStatus(SessionVariable.EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED);
+        Assertions.assertEquals(TransactionStatus.COMMITTED,
+                BaseExternalTableInsertExecutor.getExternalTableDmlReturnStatus(sessionVariable));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
@@ -136,8 +136,34 @@ public class SessionVariablesTest extends TestWithFeService {
         Assertions.assertEquals(numOfForwardVars, vars.size());
 
         vars.put(SessionVariable.ENABLE_PROFILE, "true");
+        // Forwarded string enums should be normalized because the forward path bypasses session setters.
+        vars.put(SessionVariable.EXTERNAL_TABLE_DML_RETURN_STATUS, "COMMITTED");
         sessionVariable.setForwardedSessionVariables(vars);
         Assertions.assertTrue(sessionVariable.enableProfile);
+        Assertions.assertEquals(SessionVariable.EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED,
+                sessionVariable.getExternalTableDmlReturnStatus());
+    }
+
+    @Test
+    public void testExternalTableDmlReturnStatus() throws Exception {
+        connectContext.setThreadLocalInfo();
+        SessionVariable sessionVar = connectContext.getSessionVariable();
+
+        // Explicit session settings should keep a normalized value that can be forwarded to master FE.
+        String sql = "set external_table_dml_return_status='COMMITTED'";
+        SetStmt setStmt = (SetStmt) parseAndAnalyzeStmt(sql, connectContext);
+        SetExecutor setExecutor = new SetExecutor(connectContext, setStmt);
+        setExecutor.execute();
+        Assertions.assertEquals(SessionVariable.EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED,
+                sessionVar.getExternalTableDmlReturnStatus());
+        Assertions.assertEquals(SessionVariable.EXTERNAL_TABLE_DML_RETURN_STATUS_COMMITTED,
+                sessionVar.getForwardVariables().get(SessionVariable.EXTERNAL_TABLE_DML_RETURN_STATUS));
+
+        sql = "set external_table_dml_return_status='invalid'";
+        setStmt = (SetStmt) parseAndAnalyzeStmt(sql, connectContext);
+        SetExecutor invalidExecutor = new SetExecutor(connectContext, setStmt);
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "externalTableDmlReturnStatus value is invalid",
+                invalidExecutor::execute);
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: None

Related PR: None

Problem Summary: Add a session variable named external_table_dml_return_status to control whether successful external table CTAS and INSERT INTO SELECT return VISIBLE or COMMITTED . The variable is forwarded to master FE so the behavior is consistent for forwarded execution on non-master FE nodes.

### Release note
Allow users to choose the returned success status for external table CTAS and INSERT INTO SELECT through a session variable. The default mode is visible .

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

