### PR TITLE
[improvement](fe) Add session control for insert visible timeout return mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
@@ -212,6 +212,9 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
                 ctx.getSessionVariable().getInsertVisibleTimeoutMs())) {
             txnStatus = TransactionStatus.VISIBLE;
         } else {
+            // When publish times out after a successful commit, the session variable controls whether
+            // Nereids keeps the legacy OK+COMMITTED behavior or reports the timeout as an explicit error.
+            StmtExecutor.handleInsertVisibleTimeout(ctx.getSessionVariable());
             txnStatus = TransactionStatus.COMMITTED;
         }
         if (Config.isCloudMode()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
@@ -45,6 +45,7 @@ import org.apache.doris.planner.OlapTableSink;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState.MysqlStateType;
+import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.service.ExecuteEnv;
 import org.apache.doris.service.FrontendOptions;
@@ -75,7 +76,7 @@ import java.util.stream.Collectors;
  */
 public class OlapInsertExecutor extends AbstractInsertExecutor {
     private static final Logger LOG = LogManager.getLogger(OlapInsertExecutor.class);
-    // Keep the timeout message aligned with the client-facing error returned by the legacy insert path.
+    // Follow the legacy timeout message style while adding the session timeout detail for diagnostics.
     private static final String INSERT_VISIBLE_TIMEOUT_ERROR_MSG = "transaction commit successfully, "
             + "BUT data did not become visible within insert_visible_timeout_ms and will be visible later.";
     protected TransactionStatus txnStatus = TransactionStatus.ABORTED;
@@ -324,6 +325,10 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
         ctx.getState().setOk(loadedRows, filteredRows, sb.toString());
         recordInsertResult();
         if (publishTimedOutAfterCommit && ctx.getSessionVariable().isInsertVisibleTimeoutReturnError()) {
+            // Log the committed timeout branch explicitly so operators can distinguish it from real failures.
+            LOG.warn("insert [{}] with txn id {} committed but return error because {}={}",
+                    labelName, txnId, SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE,
+                    SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR);
             // Convert the final client response to ERR after all committed-side bookkeeping has finished.
             ctx.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR, INSERT_VISIBLE_TIMEOUT_ERROR_MSG);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
@@ -212,10 +212,10 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
                 ctx.getSessionVariable().getInsertVisibleTimeoutMs())) {
             txnStatus = TransactionStatus.VISIBLE;
         } else {
-            // When publish times out after a successful commit, the session variable controls whether
-            // Nereids keeps the legacy OK+COMMITTED behavior or reports the timeout as an explicit error.
-            StmtExecutor.handleInsertVisibleTimeout(ctx.getSessionVariable());
             txnStatus = TransactionStatus.COMMITTED;
+            // Keep the committed internal status before raising the client-side timeout error so that
+            // the timeout path stays aligned with explicit transaction commit semantics.
+            StmtExecutor.handleInsertVisibleTimeout(ctx.getSessionVariable());
         }
         if (Config.isCloudMode()) {
             String clusterName = ctx.getCloudCluster();
@@ -238,9 +238,10 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
     protected void onFail(Throwable t) {
         errMsg = t.getMessage() == null ? "unknown reason" : t.getMessage();
         String queryId = DebugUtil.printId(ctx.queryId());
-        // if any throwable being thrown during insert operation, first we should abort this txn
+        // Abort only when the transaction has not been committed yet. Publish-timeout errors are
+        // raised after a successful commit and should keep the committed status for diagnostics.
         LOG.warn("insert [{}] with query id {} failed", labelName, queryId, t);
-        if (txnId != INVALID_TXN_ID) {
+        if (txnId != INVALID_TXN_ID && txnStatus != TransactionStatus.COMMITTED) {
             try {
                 Env.getCurrentGlobalTransactionMgr().abortTransaction(
                         database.getId(), txnId, errMsg);
@@ -250,6 +251,9 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
                 LOG.warn("insert [{}] with query id {} abort txn {} failed",
                         labelName, queryId, txnId, abortTxnException);
             }
+        }
+        if (txnStatus == TransactionStatus.COMMITTED) {
+            recordInsertResult();
         }
         // retry insert into from select when meet "need re-plan error" in cloud
         if (Config.isCloudMode() && SystemInfoService.needRetryWithReplan(t.getMessage())) {
@@ -313,11 +317,14 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
         sb.append("}");
 
         ctx.getState().setOk(loadedRows, filteredRows, sb.toString());
-        // set insert result in connection context,
-        // so that user can use `show insert result` to get info of the last insert operation.
+        recordInsertResult();
+    }
+
+    private void recordInsertResult() {
+        // Save the actual insert status in the connection context even when the client-facing
+        // response is turned into an error after the transaction has already been committed.
         ctx.setOrUpdateInsertResult(txnId, labelName, database.getFullName(), table.getName(),
                 txnStatus, loadedRows, filteredRows);
-        // update it, so that user can get loaded rows in fe.audit.log
         ctx.updateReturnRows((int) loadedRows);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
@@ -75,7 +75,12 @@ import java.util.stream.Collectors;
  */
 public class OlapInsertExecutor extends AbstractInsertExecutor {
     private static final Logger LOG = LogManager.getLogger(OlapInsertExecutor.class);
+    // Keep the timeout message aligned with the client-facing error returned by the legacy insert path.
+    private static final String INSERT_VISIBLE_TIMEOUT_ERROR_MSG = "transaction commit successfully, "
+            + "BUT data did not become visible within insert_visible_timeout_ms and will be visible later.";
     protected TransactionStatus txnStatus = TransactionStatus.ABORTED;
+    // Track publish timeout separately from real failures so finished load jobs keep committed metadata.
+    protected boolean publishTimedOutAfterCommit = false;
 
     /**
      * constructor
@@ -212,10 +217,10 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
                 ctx.getSessionVariable().getInsertVisibleTimeoutMs())) {
             txnStatus = TransactionStatus.VISIBLE;
         } else {
+            // Preserve the committed status and continue with the normal completion path so accounting,
+            // persistence, and cloud sync stay aligned with committed mode.
             txnStatus = TransactionStatus.COMMITTED;
-            // Keep the committed internal status before raising the client-side timeout error so that
-            // the timeout path stays aligned with explicit transaction commit semantics.
-            StmtExecutor.handleInsertVisibleTimeout(ctx.getSessionVariable());
+            publishTimedOutAfterCommit = true;
         }
         if (Config.isCloudMode()) {
             String clusterName = ctx.getCloudCluster();
@@ -238,8 +243,8 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
     protected void onFail(Throwable t) {
         errMsg = t.getMessage() == null ? "unknown reason" : t.getMessage();
         String queryId = DebugUtil.printId(ctx.queryId());
-        // Abort only when the transaction has not been committed yet. Publish-timeout errors are
-        // raised after a successful commit and should keep the committed status for diagnostics.
+        // Abort only when the transaction has not been committed yet. Failures raised after a
+        // successful commit should keep the committed status for diagnostics.
         LOG.warn("insert [{}] with query id {} failed", labelName, queryId, t);
         if (txnId != INVALID_TXN_ID && txnStatus != TransactionStatus.COMMITTED) {
             try {
@@ -318,6 +323,10 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
 
         ctx.getState().setOk(loadedRows, filteredRows, sb.toString());
         recordInsertResult();
+        if (publishTimedOutAfterCommit && ctx.getSessionVariable().isInsertVisibleTimeoutReturnError()) {
+            // Convert the final client response to ERR after all committed-side bookkeeping has finished.
+            ctx.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR, INSERT_VISIBLE_TIMEOUT_ERROR_MSG);
+        }
     }
 
     private void recordInsertResult() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -222,6 +222,9 @@ public class SessionVariable implements Serializable, Writable {
 
     // max ms to wait transaction publish finish when exec insert stmt.
     public static final String INSERT_VISIBLE_TIMEOUT_MS = "insert_visible_timeout_ms";
+    public static final String INSERT_VISIBLE_TIMEOUT_RETURN_MODE = "insert_visible_timeout_return_mode";
+    public static final String INSERT_VISIBLE_TIMEOUT_RETURN_MODE_COMMITTED = "committed";
+    public static final String INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR = "error";
 
     public static final String DELETE_WITHOUT_PARTITION = "delete_without_partition";
 
@@ -794,6 +797,11 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = INSERT_VISIBLE_TIMEOUT_MS, needForward = true)
     public long insertVisibleTimeoutMs = DEFAULT_INSERT_VISIBLE_TIMEOUT_MS;
+
+    // This mode only changes how normal internal-table inserts report publish timeout to clients.
+    @VariableMgr.VarAttr(name = INSERT_VISIBLE_TIMEOUT_RETURN_MODE, needForward = true,
+            checker = "checkInsertVisibleTimeoutReturnMode", setter = "setInsertVisibleTimeoutReturnMode")
+    public String insertVisibleTimeoutReturnMode = INSERT_VISIBLE_TIMEOUT_RETURN_MODE_COMMITTED;
 
     // max memory used on every backend.
     @VariableMgr.VarAttr(name = EXEC_MEM_LIMIT)
@@ -3736,6 +3744,18 @@ public class SessionVariable implements Serializable, Writable {
         }
     }
 
+    public String getInsertVisibleTimeoutReturnMode() {
+        return insertVisibleTimeoutReturnMode;
+    }
+
+    public boolean isInsertVisibleTimeoutReturnError() {
+        return INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR.equals(insertVisibleTimeoutReturnMode);
+    }
+
+    public void setInsertVisibleTimeoutReturnMode(String insertVisibleTimeoutReturnMode) {
+        this.insertVisibleTimeoutReturnMode = normalizeInsertVisibleTimeoutReturnMode(insertVisibleTimeoutReturnMode);
+    }
+
     public boolean getIsSingleSetVar() {
         return isSingleSetVar;
     }
@@ -4481,6 +4501,8 @@ public class SessionVariable implements Serializable, Writable {
         } catch (Exception e) {
             throw new IOException("failed to read session variable: " + e.getMessage());
         }
+        // Normalize serialized string enums so restored sessions keep the same semantics.
+        insertVisibleTimeoutReturnMode = normalizeInsertVisibleTimeoutReturnMode(insertVisibleTimeoutReturnMode);
     }
 
     /**
@@ -4551,6 +4573,8 @@ public class SessionVariable implements Serializable, Writable {
         } catch (IllegalAccessException e) {
             LOG.error("failed to set forward variables", e);
         }
+        // Normalize forwarded string enums because forwarded assignments bypass dedicated setters.
+        insertVisibleTimeoutReturnMode = normalizeInsertVisibleTimeoutReturnMode(insertVisibleTimeoutReturnMode);
     }
 
     /**
@@ -4844,6 +4868,23 @@ public class SessionVariable implements Serializable, Writable {
         }
     }
 
+    public void checkInsertVisibleTimeoutReturnMode(String mode) {
+        if (StringUtils.isEmpty(mode)) {
+            LOG.warn("insertVisibleTimeoutReturnMode value is empty");
+            throw new UnsupportedOperationException("insertVisibleTimeoutReturnMode value is empty");
+        }
+        if (!INSERT_VISIBLE_TIMEOUT_RETURN_MODE_COMMITTED.equalsIgnoreCase(mode)
+                && !INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR.equalsIgnoreCase(mode)) {
+            LOG.warn("insertVisibleTimeoutReturnMode value is invalid, the invalid value is {}", mode);
+            throw new UnsupportedOperationException(
+                    "insertVisibleTimeoutReturnMode value is invalid, the invalid value is " + mode);
+        }
+    }
+
+    public String normalizeInsertVisibleTimeoutReturnMode(String mode) {
+        return mode == null ? null : mode.toLowerCase();
+    }
+
     public void checkBatchSize(String batchSize) {
         Long batchSizeValue = Long.valueOf(batchSize);
         if (batchSizeValue < 1 || batchSizeValue > 65535) {
@@ -5075,4 +5116,3 @@ public class SessionVariable implements Serializable, Writable {
         return defaultVariantMaxSparseColumnStatisticsSize;
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -804,7 +804,11 @@ public class SessionVariable implements Serializable, Writable {
 
     // This mode only changes how normal internal-table inserts report publish timeout to clients.
     @VariableMgr.VarAttr(name = INSERT_VISIBLE_TIMEOUT_RETURN_MODE, needForward = true,
-            checker = "checkInsertVisibleTimeoutReturnMode", setter = "setInsertVisibleTimeoutReturnMode")
+            checker = "checkInsertVisibleTimeoutReturnMode", setter = "setInsertVisibleTimeoutReturnMode",
+            description = {"控制普通内表 INSERT 在 publish timeout 时返回给客户端的状态。",
+                    "Controls the status returned to the client when a normal internal-table INSERT times out "
+                            + "while waiting for publish visibility."},
+            options = {INSERT_VISIBLE_TIMEOUT_RETURN_MODE_COMMITTED, INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR})
     public String insertVisibleTimeoutReturnMode = INSERT_VISIBLE_TIMEOUT_RETURN_MODE_COMMITTED;
 
     // max memory used on every backend.
@@ -4911,7 +4915,7 @@ public class SessionVariable implements Serializable, Writable {
     }
 
     public String normalizeInsertVisibleTimeoutReturnMode(String mode) {
-        return mode == null ? null : mode.toLowerCase();
+        return mode == null ? null : mode.toLowerCase(Locale.ROOT);
     }
 
     public void checkExternalTableDmlReturnStatus(String externalTableDmlReturnStatus) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -263,9 +263,6 @@ import java.util.stream.Collectors;
 // second: Do handle function for statement.
 public class StmtExecutor {
     private static final Logger LOG = LogManager.getLogger(StmtExecutor.class);
-    static final String INSERT_VISIBLE_TIMEOUT_ERROR_MSG = "transaction commit successfully, "
-            + "BUT data did not become visible within insert_visible_timeout_ms and will be visible later.";
-
     private static final AtomicLong STMT_ID_GENERATOR = new AtomicLong(0);
     public static final int MAX_DATA_TO_SEND_FOR_TXN = 100;
     private static Set<String> blockSqlAstNames = Sets.newHashSet();
@@ -306,16 +303,6 @@ public class StmtExecutor {
     // Only one column to indicate the real return row numbers.
     private static final CommonResultSetMetaData DRY_RUN_QUERY_METADATA = new CommonResultSetMetaData(
             Lists.newArrayList(new Column("ReturnedRows", PrimitiveType.STRING)));
-
-    public static void handleInsertVisibleTimeout(SessionVariable sessionVariable) throws AnalysisException {
-        if (sessionVariable != null && sessionVariable.isInsertVisibleTimeoutReturnError()) {
-            throwInsertVisibleTimeoutException();
-        }
-    }
-
-    public static void throwInsertVisibleTimeoutException() throws AnalysisException {
-        throw new AnalysisException(INSERT_VISIBLE_TIMEOUT_ERROR_MSG);
-    }
 
     // this constructor is mainly for proxy
     public StmtExecutor(ConnectContext context, OriginStatement originStmt, boolean isProxy) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -263,6 +263,8 @@ import java.util.stream.Collectors;
 // second: Do handle function for statement.
 public class StmtExecutor {
     private static final Logger LOG = LogManager.getLogger(StmtExecutor.class);
+    static final String INSERT_VISIBLE_TIMEOUT_ERROR_MSG = "transaction commit successfully, "
+            + "BUT data did not become visible within insert_visible_timeout_ms and will be visible later.";
 
     private static final AtomicLong STMT_ID_GENERATOR = new AtomicLong(0);
     public static final int MAX_DATA_TO_SEND_FOR_TXN = 100;
@@ -304,6 +306,16 @@ public class StmtExecutor {
     // Only one column to indicate the real return row numbers.
     private static final CommonResultSetMetaData DRY_RUN_QUERY_METADATA = new CommonResultSetMetaData(
             Lists.newArrayList(new Column("ReturnedRows", PrimitiveType.STRING)));
+
+    public static void handleInsertVisibleTimeout(SessionVariable sessionVariable) throws AnalysisException {
+        if (sessionVariable != null && sessionVariable.isInsertVisibleTimeoutReturnError()) {
+            throwInsertVisibleTimeoutException();
+        }
+    }
+
+    public static void throwInsertVisibleTimeoutException() throws AnalysisException {
+        throw new AnalysisException(INSERT_VISIBLE_TIMEOUT_ERROR_MSG);
+    }
 
     // this constructor is mainly for proxy
     public StmtExecutor(ConnectContext context, OriginStatement originStmt, boolean isProxy) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutorTest.java
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands.insert;
+
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.EnvFactory;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.profile.ExecutionProfile;
+import org.apache.doris.nereids.NereidsPlanner;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.Coordinator;
+import org.apache.doris.qe.InsertResult;
+import org.apache.doris.qe.QueryState.MysqlStateType;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.thrift.TUniqueId;
+import org.apache.doris.transaction.GlobalTransactionMgrIface;
+import org.apache.doris.transaction.TransactionStatus;
+import org.apache.doris.utframe.TestWithFeService;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+/**
+ * Tests for publish-timeout behaviors in {@link OlapInsertExecutor}.
+ */
+public class OlapInsertExecutorTest extends TestWithFeService {
+
+    @Override
+    protected void runBeforeAll() {
+    }
+
+    @Test
+    public void testPublishTimeoutReturnErrorKeepsCommittedStatus() throws Exception {
+        ConnectContext ctx = createExecutorContext();
+        ctx.getSessionVariable().setInsertVisibleTimeoutReturnMode(
+                SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR);
+
+        Coordinator coordinator = createCoordinator();
+        GlobalTransactionMgrIface txnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+
+        // Mock the transaction publish result so the executor enters the timeout branch.
+        try (MockedStatic<EnvFactory> envFactoryMock = Mockito.mockStatic(EnvFactory.class);
+                MockedStatic<Env> envMock = Mockito.mockStatic(Env.class)) {
+            prepareFactoryMocks(envFactoryMock, envMock, coordinator, txnMgr);
+            Mockito.when(txnMgr.commitAndPublishTransaction(
+                    Mockito.any(), Mockito.anyList(), Mockito.anyLong(), Mockito.anyList(), Mockito.anyLong()))
+                    .thenReturn(false);
+
+            OlapInsertExecutor executor = createExecutor(ctx);
+            executor.txnId = 10001L;
+            executor.loadedRows = 12L;
+            executor.filteredRows = 1;
+
+            Exception exception = Assertions.assertThrows(Exception.class, executor::onComplete);
+            executor.onFail(exception);
+
+            Assertions.assertEquals(TransactionStatus.COMMITTED, executor.txnStatus);
+            Assertions.assertEquals(MysqlStateType.ERR, ctx.getState().getStateType());
+            Assertions.assertTrue(ctx.getState().getErrorMessage().contains(
+                    "transaction commit successfully, BUT data did not become visible within "
+                            + "insert_visible_timeout_ms and will be visible later."));
+
+            InsertResult insertResult = ctx.getInsertResult();
+            Assertions.assertNotNull(insertResult);
+            Assertions.assertEquals(TransactionStatus.COMMITTED, insertResult.txnStatus);
+            Assertions.assertEquals(12L, insertResult.loadedRows);
+            Assertions.assertEquals(1L, insertResult.filteredRows);
+            Assertions.assertEquals(12L, ctx.getReturnRows());
+
+            Mockito.verify(txnMgr, Mockito.never()).abortTransaction(Mockito.anyLong(), Mockito.anyLong(),
+                    Mockito.anyString());
+        }
+    }
+
+    @Test
+    public void testPublishTimeoutCommittedModeReturnsOk() throws Exception {
+        ConnectContext ctx = createExecutorContext();
+        Coordinator coordinator = createCoordinator();
+        GlobalTransactionMgrIface txnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        boolean originEnableNereidsLoad = org.apache.doris.common.Config.enable_nereids_load;
+
+        // Keep afterExec focused on client-visible return info so the test only covers timeout handling.
+        org.apache.doris.common.Config.enable_nereids_load = true;
+        try (MockedStatic<EnvFactory> envFactoryMock = Mockito.mockStatic(EnvFactory.class);
+                MockedStatic<Env> envMock = Mockito.mockStatic(Env.class)) {
+            prepareFactoryMocks(envFactoryMock, envMock, coordinator, txnMgr);
+            Mockito.when(txnMgr.commitAndPublishTransaction(
+                    Mockito.any(), Mockito.anyList(), Mockito.anyLong(), Mockito.anyList(), Mockito.anyLong()))
+                    .thenReturn(false);
+
+            OlapInsertExecutor executor = createExecutor(ctx);
+            executor.txnId = 10002L;
+            executor.loadedRows = 20L;
+            executor.filteredRows = 2;
+
+            executor.onComplete();
+            executor.afterExec(Mockito.mock(StmtExecutor.class));
+
+            Assertions.assertEquals(TransactionStatus.COMMITTED, executor.txnStatus);
+            Assertions.assertEquals(MysqlStateType.OK, ctx.getState().getStateType());
+            Assertions.assertTrue(ctx.getState().getInfoMessage().contains("'status':'COMMITTED'"));
+
+            InsertResult insertResult = ctx.getInsertResult();
+            Assertions.assertNotNull(insertResult);
+            Assertions.assertEquals(TransactionStatus.COMMITTED, insertResult.txnStatus);
+            Assertions.assertEquals(20L, insertResult.loadedRows);
+            Assertions.assertEquals(2L, insertResult.filteredRows);
+            Assertions.assertEquals(20L, ctx.getReturnRows());
+
+            Mockito.verify(txnMgr, Mockito.never()).abortTransaction(Mockito.anyLong(), Mockito.anyLong(),
+                    Mockito.anyString());
+        } finally {
+            org.apache.doris.common.Config.enable_nereids_load = originEnableNereidsLoad;
+        }
+    }
+
+    // Build a fresh context per case so insertResult and QueryState do not leak between tests.
+    private ConnectContext createExecutorContext() {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setQueryId(new TUniqueId(1, 2));
+        ctx.getState().reset();
+        ctx.resetReturnRows();
+        return ctx;
+    }
+
+    // Prepare the mocked coordinator so the executor can run its completion logic without real execution.
+    private Coordinator createCoordinator() {
+        Coordinator coordinator = Mockito.mock(Coordinator.class);
+        Mockito.when(coordinator.getCommitInfos()).thenReturn(Lists.newArrayList());
+        Mockito.when(coordinator.getTrackingUrl()).thenReturn(null);
+        Mockito.when(coordinator.getExecutionProfile()).thenReturn(Mockito.mock(ExecutionProfile.class));
+        Mockito.when(coordinator.getLoadCounters()).thenReturn(ImmutableMap.of());
+        return coordinator;
+    }
+
+    // Create an executor with mocked table metadata because this test only validates timeout result handling.
+    private OlapInsertExecutor createExecutor(ConnectContext ctx) {
+        Database database = Mockito.mock(Database.class);
+        Mockito.when(database.getFullName()).thenReturn("test_db");
+        Mockito.when(database.getId()).thenReturn(1L);
+
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.getDatabase()).thenReturn(database);
+        Mockito.when(table.getName()).thenReturn("test_tbl");
+        Mockito.when(table.getId()).thenReturn(2L);
+
+        return new OlapInsertExecutor(ctx, table, "label_test", Mockito.mock(NereidsPlanner.class),
+                Optional.empty(), false);
+    }
+
+    // Redirect coordinator creation and transaction access to mocks so the test stays deterministic.
+    private void prepareFactoryMocks(MockedStatic<EnvFactory> envFactoryMock, MockedStatic<Env> envMock,
+            Coordinator coordinator, GlobalTransactionMgrIface txnMgr) {
+        EnvFactory envFactory = Mockito.mock(EnvFactory.class);
+        envFactoryMock.when(EnvFactory::getInstance).thenReturn(envFactory);
+        Mockito.when(envFactory.createCoordinator(Mockito.any(), Mockito.isNull(), Mockito.any(), Mockito.any()))
+                .thenReturn(coordinator);
+        envMock.when(Env::getCurrentGlobalTransactionMgr).thenReturn(txnMgr);
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutorTest.java
@@ -139,9 +139,9 @@ public class OlapInsertExecutorTest extends TestWithFeService {
             InsertResult insertResult = ctx.getInsertResult();
             Assertions.assertNotNull(insertResult);
             Assertions.assertEquals(TransactionStatus.COMMITTED, insertResult.txnStatus);
-            Assertions.assertEquals(20L, insertResult.loadedRows);
-            Assertions.assertEquals(2L, insertResult.filteredRows);
-            Assertions.assertEquals(20L, ctx.getReturnRows());
+            Assertions.assertEquals(12L, insertResult.loadedRows);
+            Assertions.assertEquals(1L, insertResult.filteredRows);
+            Assertions.assertEquals(12L, ctx.getReturnRows());
 
             Mockito.verify(txnMgr, Mockito.never()).abortTransaction(Mockito.anyLong(), Mockito.anyLong(),
                     Mockito.anyString());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutorTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.Status;
 import org.apache.doris.common.profile.ExecutionProfile;
 import org.apache.doris.common.profile.Profile;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.datasource.hive.HiveTransactionMgr;
 import org.apache.doris.load.loadv2.LoadManager;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.qe.ConnectContext;
@@ -35,6 +36,7 @@ import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.task.LoadEtlTask;
 import org.apache.doris.thrift.TStatusCode;
+import org.apache.doris.thrift.TQueryOptions;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.GlobalTransactionMgrIface;
 import org.apache.doris.transaction.TransactionStatus;
@@ -154,6 +156,8 @@ public class OlapInsertExecutorTest extends TestWithFeService {
     private ConnectContext createExecutorContext() {
         ConnectContext ctx = new ConnectContext();
         ctx.setQueryId(new TUniqueId(1, 2));
+        // Disable strict insert mode because this test intentionally keeps one filtered row in the mocked counters.
+        ctx.getSessionVariable().setEnableInsertStrict(false);
         ctx.getState().reset();
         ctx.resetReturnRows();
         return ctx;
@@ -165,6 +169,8 @@ public class OlapInsertExecutorTest extends TestWithFeService {
         Mockito.when(coordinator.join(Mockito.anyInt())).thenReturn(true);
         Mockito.when(coordinator.isDone()).thenReturn(true);
         Mockito.when(coordinator.getExecStatus()).thenReturn(new Status(TStatusCode.OK, ""));
+        // Provide default query options so the real insert execution path can access profile flags safely.
+        Mockito.when(coordinator.getQueryOptions()).thenReturn(new TQueryOptions());
         Mockito.when(coordinator.getCommitInfos()).thenReturn(Lists.newArrayList());
         Mockito.when(coordinator.getTrackingUrl()).thenReturn(null);
         Mockito.when(coordinator.getExecutionProfile()).thenReturn(Mockito.mock(ExecutionProfile.class));
@@ -211,9 +217,12 @@ public class OlapInsertExecutorTest extends TestWithFeService {
     private void prepareFactoryMocks(MockedStatic<EnvFactory> envFactoryMock, MockedStatic<Env> envMock,
             Coordinator coordinator, GlobalTransactionMgrIface txnMgr) {
         EnvFactory envFactory = Mockito.mock(EnvFactory.class);
+        HiveTransactionMgr hiveTransactionMgr = Mockito.mock(HiveTransactionMgr.class);
         envFactoryMock.when(EnvFactory::getInstance).thenReturn(envFactory);
         Mockito.when(envFactory.createCoordinator(Mockito.any(), Mockito.isNull(), Mockito.any(), Mockito.any()))
                 .thenReturn(coordinator);
         envMock.when(Env::getCurrentGlobalTransactionMgr).thenReturn(txnMgr);
+        // Provide a no-op hive transaction manager so unregisterQuery() can finish its cleanup path safely.
+        envMock.when(Env::getCurrentHiveTransactionMgr).thenReturn(hiveTransactionMgr);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutorTest.java
@@ -21,7 +21,11 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.EnvFactory;
 import org.apache.doris.catalog.Table;
+import org.apache.doris.common.Status;
 import org.apache.doris.common.profile.ExecutionProfile;
+import org.apache.doris.common.profile.Profile;
+import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.load.loadv2.LoadManager;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.Coordinator;
@@ -29,6 +33,8 @@ import org.apache.doris.qe.InsertResult;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.task.LoadEtlTask;
+import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.GlobalTransactionMgrIface;
 import org.apache.doris.transaction.TransactionStatus;
@@ -38,6 +44,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -53,29 +60,30 @@ public class OlapInsertExecutorTest extends TestWithFeService {
     }
 
     @Test
-    public void testPublishTimeoutReturnErrorKeepsCommittedStatus() throws Exception {
+    public void testExecuteSingleInsertPublishTimeoutReturnErrorKeepsCommittedAccounting() throws Exception {
         ConnectContext ctx = createExecutorContext();
         ctx.getSessionVariable().setInsertVisibleTimeoutReturnMode(
                 SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR);
 
         Coordinator coordinator = createCoordinator();
         GlobalTransactionMgrIface txnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        LoadManager loadManager = Mockito.mock(LoadManager.class);
+        StmtExecutor stmtExecutor = createStmtExecutor();
+        boolean originEnableNereidsLoad = org.apache.doris.common.Config.enable_nereids_load;
 
-        // Mock the transaction publish result so the executor enters the timeout branch.
+        // Keep loadv2 recording enabled so the test validates the full committed accounting path.
+        org.apache.doris.common.Config.enable_nereids_load = false;
         try (MockedStatic<EnvFactory> envFactoryMock = Mockito.mockStatic(EnvFactory.class);
                 MockedStatic<Env> envMock = Mockito.mockStatic(Env.class)) {
             prepareFactoryMocks(envFactoryMock, envMock, coordinator, txnMgr);
+            prepareContextEnv(ctx, loadManager);
             Mockito.when(txnMgr.commitAndPublishTransaction(
                     Mockito.any(), Mockito.anyList(), Mockito.anyLong(), Mockito.anyList(), Mockito.anyLong()))
                     .thenReturn(false);
 
             OlapInsertExecutor executor = createExecutor(ctx);
             executor.txnId = 10001L;
-            executor.loadedRows = 12L;
-            executor.filteredRows = 1;
-
-            Exception exception = Assertions.assertThrows(Exception.class, executor::onComplete);
-            executor.onFail(exception);
+            executor.executeSingleInsert(stmtExecutor, 0L);
 
             Assertions.assertEquals(TransactionStatus.COMMITTED, executor.txnStatus);
             Assertions.assertEquals(MysqlStateType.ERR, ctx.getState().getStateType());
@@ -90,8 +98,16 @@ public class OlapInsertExecutorTest extends TestWithFeService {
             Assertions.assertEquals(1L, insertResult.filteredRows);
             Assertions.assertEquals(12L, ctx.getReturnRows());
 
+            // The finished load job must still be recorded even when the client response becomes ERR.
+            ArgumentCaptor<String> failMsgCaptor = ArgumentCaptor.forClass(String.class);
+            Mockito.verify(loadManager).recordFinishedLoadJob(Mockito.eq("label_test"), Mockito.eq(10001L),
+                    Mockito.eq("test_db"), Mockito.eq(2L), Mockito.any(), Mockito.anyLong(), failMsgCaptor.capture(),
+                    Mockito.isNull(), Mockito.isNull(), Mockito.eq(0L));
+            Assertions.assertEquals("", failMsgCaptor.getValue());
             Mockito.verify(txnMgr, Mockito.never()).abortTransaction(Mockito.anyLong(), Mockito.anyLong(),
                     Mockito.anyString());
+        } finally {
+            org.apache.doris.common.Config.enable_nereids_load = originEnableNereidsLoad;
         }
     }
 
@@ -100,9 +116,10 @@ public class OlapInsertExecutorTest extends TestWithFeService {
         ConnectContext ctx = createExecutorContext();
         Coordinator coordinator = createCoordinator();
         GlobalTransactionMgrIface txnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        StmtExecutor stmtExecutor = createStmtExecutor();
         boolean originEnableNereidsLoad = org.apache.doris.common.Config.enable_nereids_load;
 
-        // Keep afterExec focused on client-visible return info so the test only covers timeout handling.
+        // Skip loadv2 recording in this case so the test stays focused on the committed-mode response path.
         org.apache.doris.common.Config.enable_nereids_load = true;
         try (MockedStatic<EnvFactory> envFactoryMock = Mockito.mockStatic(EnvFactory.class);
                 MockedStatic<Env> envMock = Mockito.mockStatic(Env.class)) {
@@ -113,11 +130,7 @@ public class OlapInsertExecutorTest extends TestWithFeService {
 
             OlapInsertExecutor executor = createExecutor(ctx);
             executor.txnId = 10002L;
-            executor.loadedRows = 20L;
-            executor.filteredRows = 2;
-
-            executor.onComplete();
-            executor.afterExec(Mockito.mock(StmtExecutor.class));
+            executor.executeSingleInsert(stmtExecutor, 0L);
 
             Assertions.assertEquals(TransactionStatus.COMMITTED, executor.txnStatus);
             Assertions.assertEquals(MysqlStateType.OK, ctx.getState().getStateType());
@@ -149,11 +162,24 @@ public class OlapInsertExecutorTest extends TestWithFeService {
     // Prepare the mocked coordinator so the executor can run its completion logic without real execution.
     private Coordinator createCoordinator() {
         Coordinator coordinator = Mockito.mock(Coordinator.class);
+        Mockito.when(coordinator.join(Mockito.anyInt())).thenReturn(true);
+        Mockito.when(coordinator.isDone()).thenReturn(true);
+        Mockito.when(coordinator.getExecStatus()).thenReturn(new Status(TStatusCode.OK, ""));
         Mockito.when(coordinator.getCommitInfos()).thenReturn(Lists.newArrayList());
         Mockito.when(coordinator.getTrackingUrl()).thenReturn(null);
         Mockito.when(coordinator.getExecutionProfile()).thenReturn(Mockito.mock(ExecutionProfile.class));
-        Mockito.when(coordinator.getLoadCounters()).thenReturn(ImmutableMap.of());
+        Mockito.when(coordinator.getLoadCounters()).thenReturn(ImmutableMap.of(
+                LoadEtlTask.DPP_NORMAL_ALL, "12",
+                LoadEtlTask.DPP_ABNORMAL_ALL, "1"));
         return coordinator;
+    }
+
+    // Use a mocked executor so executeSingleInsert can run the real control flow without a full query setup.
+    private StmtExecutor createStmtExecutor() {
+        StmtExecutor stmtExecutor = Mockito.mock(StmtExecutor.class);
+        Mockito.when(stmtExecutor.getProfile()).thenReturn(Mockito.mock(Profile.class));
+        Mockito.when(stmtExecutor.getOriginStmtInString()).thenReturn("insert into test_tbl select 1");
+        return stmtExecutor;
     }
 
     // Create an executor with mocked table metadata because this test only validates timeout result handling.
@@ -169,6 +195,16 @@ public class OlapInsertExecutorTest extends TestWithFeService {
 
         return new OlapInsertExecutor(ctx, table, "label_test", Mockito.mock(NereidsPlanner.class),
                 Optional.empty(), false);
+    }
+
+    // Attach a mocked env so afterExec can record the finished load job without depending on a real FE env.
+    private void prepareContextEnv(ConnectContext ctx, LoadManager loadManager) {
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog internalCatalog = Mockito.mock(InternalCatalog.class);
+        Mockito.when(env.getInternalCatalog()).thenReturn(internalCatalog);
+        Mockito.when(internalCatalog.getName()).thenReturn("internal");
+        Mockito.when(env.getLoadManager()).thenReturn(loadManager);
+        ctx.setEnv(env);
     }
 
     // Redirect coordinator creation and transaction access to mocks so the test stays deterministic.

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class SessionVariablesTest extends TestWithFeService {
@@ -213,6 +214,28 @@ public class SessionVariablesTest extends TestWithFeService {
         restored.readFromJson("{\"insert_visible_timeout_return_mode\":\"ERROR\"}");
         Assertions.assertEquals(SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR,
                 restored.getInsertVisibleTimeoutReturnMode());
+
+        // Keep normalization locale-independent so variable persistence and display are stable.
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            Assertions.assertEquals(SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_COMMITTED,
+                    restored.normalizeInsertVisibleTimeoutReturnMode("COMMITTED"));
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+
+        Field field = SessionVariable.class.getDeclaredField("insertVisibleTimeoutReturnMode");
+        VariableMgr.VarAttr varAttr = field.getAnnotation(VariableMgr.VarAttr.class);
+        Assertions.assertArrayEquals(new String[] {
+                "控制普通内表 INSERT 在 publish timeout 时返回给客户端的状态。",
+                "Controls the status returned to the client when a normal internal-table INSERT times out "
+                        + "while waiting for publish visibility."
+        }, varAttr.description());
+        Assertions.assertArrayEquals(new String[] {
+                SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_COMMITTED,
+                SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR
+        }, varAttr.options());
 
         sql = "set insert_visible_timeout_return_mode='unexpected'";
         setStmt = (SetStmt) parseAndAnalyzeStmt(sql, connectContext);

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
@@ -136,8 +136,11 @@ public class SessionVariablesTest extends TestWithFeService {
         Assertions.assertEquals(numOfForwardVars, vars.size());
 
         vars.put(SessionVariable.ENABLE_PROFILE, "true");
+        vars.put(SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE, "ERROR");
         sessionVariable.setForwardedSessionVariables(vars);
         Assertions.assertTrue(sessionVariable.enableProfile);
+        Assertions.assertEquals(SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR,
+                sessionVariable.getInsertVisibleTimeoutReturnMode());
     }
 
     @Test
@@ -164,5 +167,29 @@ public class SessionVariablesTest extends TestWithFeService {
 
         Assertions.assertEquals("test",
                 sessionVariableClone.getSessionOriginValue().get(txIsolationSessionVariableField));
+    }
+
+    @Test
+    public void testInsertVisibleTimeoutReturnMode() throws Exception {
+        connectContext.setThreadLocalInfo();
+        SessionVariable sessionVar = connectContext.getSessionVariable();
+
+        String sql = "set insert_visible_timeout_return_mode='ERROR'";
+        SetStmt setStmt = (SetStmt) parseAndAnalyzeStmt(sql, connectContext);
+        SetExecutor setExecutor = new SetExecutor(connectContext, setStmt);
+        setExecutor.execute();
+        Assertions.assertEquals(SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR,
+                sessionVar.getInsertVisibleTimeoutReturnMode());
+
+        SessionVariable restored = new SessionVariable();
+        restored.readFromJson("{\"insert_visible_timeout_return_mode\":\"ERROR\"}");
+        Assertions.assertEquals(SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR,
+                restored.getInsertVisibleTimeoutReturnMode());
+
+        sql = "set insert_visible_timeout_return_mode='unexpected'";
+        setStmt = (SetStmt) parseAndAnalyzeStmt(sql, connectContext);
+        SetExecutor invalidSetExecutor = new SetExecutor(connectContext, setStmt);
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "insertVisibleTimeoutReturnMode value is invalid", invalidSetExecutor::execute);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -20,7 +20,6 @@ package org.apache.doris.qe;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.InternalSchemaInitializer;
 import org.apache.doris.catalog.PrimitiveType;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.mysql.MysqlChannel;
@@ -276,16 +275,5 @@ public class StmtExecutorTest extends TestWithFeService {
 
         StmtExecutor executor = new StmtExecutor(mockCtx, stmt, false);
         executor.sendBinaryResultRow(resultSet);
-    }
-
-    @Test
-    public void testInsertVisibleTimeoutErrorHelper() {
-        SessionVariable sessionVariable = VariableMgr.newSessionVariable();
-        Assertions.assertDoesNotThrow(() -> StmtExecutor.handleInsertVisibleTimeout(sessionVariable));
-
-        sessionVariable.setInsertVisibleTimeoutReturnMode(SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR);
-        AnalysisException exception = Assertions.assertThrows(AnalysisException.class,
-                () -> StmtExecutor.handleInsertVisibleTimeout(sessionVariable));
-        Assertions.assertEquals(StmtExecutor.INSERT_VISIBLE_TIMEOUT_ERROR_MSG, exception.getDetailMessage());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.qe;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.InternalSchemaInitializer;
 import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.mysql.MysqlChannel;
@@ -275,5 +276,16 @@ public class StmtExecutorTest extends TestWithFeService {
 
         StmtExecutor executor = new StmtExecutor(mockCtx, stmt, false);
         executor.sendBinaryResultRow(resultSet);
+    }
+
+    @Test
+    public void testInsertVisibleTimeoutErrorHelper() {
+        SessionVariable sessionVariable = VariableMgr.newSessionVariable();
+        Assertions.assertDoesNotThrow(() -> StmtExecutor.handleInsertVisibleTimeout(sessionVariable));
+
+        sessionVariable.setInsertVisibleTimeoutReturnMode(SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR);
+        AnalysisException exception = Assertions.assertThrows(AnalysisException.class,
+                () -> StmtExecutor.handleInsertVisibleTimeout(sessionVariable));
+        Assertions.assertEquals(StmtExecutor.INSERT_VISIBLE_TIMEOUT_ERROR_MSG, exception.getMessage());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -286,6 +286,6 @@ public class StmtExecutorTest extends TestWithFeService {
         sessionVariable.setInsertVisibleTimeoutReturnMode(SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR);
         AnalysisException exception = Assertions.assertThrows(AnalysisException.class,
                 () -> StmtExecutor.handleInsertVisibleTimeout(sessionVariable));
-        Assertions.assertEquals(StmtExecutor.INSERT_VISIBLE_TIMEOUT_ERROR_MSG, exception.getMessage());
+        Assertions.assertEquals(StmtExecutor.INSERT_VISIBLE_TIMEOUT_ERROR_MSG, exception.getDetailMessage());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Add a session variable named `insert_visible_timeout_return_mode` to control how Nereids internal-table inserts(create table as select from table, insert into select from table) report publish timeout after a successful commit. The default mode keeps the existing `COMMITTED` response, while `error` returns an explicit client error just like explicit transaction of insert into values. The change only applies to the Nereids normal insert path and keeps legacy, explicit transaction, and group commit behavior unchanged.

### Release note

Allow users to choose whether a Nereids internal-table insert publish timeout returns `COMMITTED` or an explicit error through a session variable.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

