### PR TITLE
[improvement](fe) Use streaming Gson adapter for RestoreJob Guava Table fields

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -99,6 +99,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Table.Cell;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -187,10 +188,14 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
 
     // save all restored partitions' version info which are already exist in catalog
     // table id -> partition id -> (version, version hash)
+    // use the streaming adapter to avoid materializing the huge JsonElement DOM tree
+    // when persisting a job with a large number of tablets
     @SerializedName("rvi")
+    @JsonAdapter(GsonUtils.GuavaTableTypeAdapterFactory.class)
     private com.google.common.collect.Table<Long, Long, Long> restoredVersionInfo = HashBasedTable.create();
     // tablet id->(be id -> snapshot info)
     @SerializedName("si")
+    @JsonAdapter(GsonUtils.GuavaTableTypeAdapterFactory.class)
     protected com.google.common.collect.Table<Long, Long, SnapshotInfo> snapshotInfos = HashBasedTable.create();
 
     // the meta version is used when reading backup meta from file.

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -232,7 +232,6 @@ import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -262,6 +261,8 @@ import java.io.OutputStreamWriter;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
@@ -614,9 +615,9 @@ public class GsonUtils {
                     new HiddenAnnotationExclusionStrategy()).serializeSpecialFloatingPointValues()
             .enableComplexMapKeySerialization()
             .addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_INACCESSIBLE_JAVA)
-            .registerTypeHierarchyAdapter(Table.class, new GuavaTableAdapter())
+            .registerTypeAdapterFactory(new GuavaTableTypeAdapterFactory())
             // .registerTypeHierarchyAdapter(Expr.class, new ExprAdapter())
-            .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
+            .registerTypeAdapterFactory(new GuavaMultimapTypeAdapterFactory())
             .registerTypeAdapterFactory(new PostProcessTypeAdapterFactory())
             .registerTypeAdapterFactory(new PreProcessTypeAdapterFactory())
             .registerTypeAdapterFactory(exprAdapterFactory)
@@ -692,109 +693,152 @@ public class GsonUtils {
 
     /*
      *
-     * The json adapter for Guava Table.
+     * The streaming json adapter factory for Guava Table.
      * Current support:
      * 1. HashBasedTable
      *
      * The RowKey, ColumnKey and Value classes in Table should also be serializable.
      *
-     * What is Adapter and Why we should implement it?
+     * serialize Table<R, C, V> as:
+     * {
+     * "clazz": "HashBasedTable",
+     * "rowKeys": [ "rowKey1", "rowKey2", ...],
+     * "columnKeys": [ "colKey1", "colKey2", ...],
+     * "cells" : [0, 0, value1, 0, 1, value2, ...]
+     * }
      *
-     * Adapter is mainly used to provide serialization and deserialization methods for some complex classes.
-     * Complex classes here usually refer to classes that are complex and cannot be modified.
-     * These classes mainly include third-party library classes or some inherited classes.
+     * the [0, 0] .. in cells are the indexes of rowKeys array and columnKeys array.
+     * This serialization method can reduce the size of json string because it
+     * replace the same row key
+     * and column key to integer.
+     *
+     * Why TypeAdapterFactory instead of JsonSerializer/JsonDeserializer?
+     *
+     * JsonSerializer/JsonDeserializer works in tree mode, which materializes the whole
+     * JsonElement DOM tree in memory before writing (or after parsing). For large tables
+     * (e.g. RestoreJob.snapshotInfos with tens of thousands of tablets), the transient DOM
+     * costs tens of times more memory than the serialized bytes and easily causes FE heap
+     * spikes. The streaming TypeAdapter writes to JsonWriter and reads from JsonReader
+     * directly, without building the DOM.
      */
-    private static class GuavaTableAdapter<R, C, V>
-            implements JsonSerializer<Table<R, C, V>>, JsonDeserializer<Table<R, C, V>> {
-        /*
-         * serialize Table<R, C, V> as:
-         * {
-         * "rowKeys": [ "rowKey1", "rowKey2", ...],
-         * "columnKeys": [ "colKey1", "colKey2", ...],
-         * "cells" : [[0, 0, value1], [0, 1, value2], ...]
-         * }
-         *
-         * the [0, 0] .. in cells are the indexes of rowKeys array and columnKeys array.
-         * This serialization method can reduce the size of json string because it
-         * replace the same row key
-         * and column key to integer.
-         */
+    private static class GuavaTableTypeAdapterFactory implements TypeAdapterFactory {
         @Override
-        public JsonElement serialize(Table<R, C, V> src, Type typeOfSrc, JsonSerializationContext context) {
-            JsonArray rowKeysJsonArray = new JsonArray();
-            Map<R, Integer> rowKeyToIndex = new HashMap<>();
-            for (R rowKey : src.rowKeySet()) {
-                rowKeyToIndex.put(rowKey, rowKeyToIndex.size());
-                rowKeysJsonArray.add(context.serialize(rowKey));
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+            if (!Table.class.isAssignableFrom(typeToken.getRawType())) {
+                return null;
             }
-            JsonArray columnKeysJsonArray = new JsonArray();
-            Map<C, Integer> columnKeyToIndex = new HashMap<>();
-            for (C columnKey : src.columnKeySet()) {
-                columnKeyToIndex.put(columnKey, columnKeyToIndex.size());
-                columnKeysJsonArray.add(context.serialize(columnKey));
-            }
-            JsonArray cellsJsonArray = new JsonArray();
-            for (Table.Cell<R, C, V> cell : src.cellSet()) {
-                int rowIndex = rowKeyToIndex.get(cell.getRowKey());
-                int columnIndex = columnKeyToIndex.get(cell.getColumnKey());
-                cellsJsonArray.add(rowIndex);
-                cellsJsonArray.add(columnIndex);
-                cellsJsonArray.add(context.serialize(cell.getValue()));
-            }
-            JsonObject tableJsonObject = new JsonObject();
-            tableJsonObject.addProperty("clazz", src.getClass().getSimpleName());
-            tableJsonObject.add("rowKeys", rowKeysJsonArray);
-            tableJsonObject.add("columnKeys", columnKeysJsonArray);
-            tableJsonObject.add("cells", cellsJsonArray);
-            return tableJsonObject;
+            Map<TypeVariable<?>, Type> typeArgs = TypeUtils.getTypeArguments(typeToken.getType(), Table.class);
+            TypeVariable<?>[] typeVars = Table.class.getTypeParameters();
+            TypeAdapter<?> rowKeyAdapter = gson.getAdapter(TypeToken.get(resolveTypeArgument(typeArgs, typeVars[0])));
+            TypeAdapter<?> columnKeyAdapter
+                    = gson.getAdapter(TypeToken.get(resolveTypeArgument(typeArgs, typeVars[1])));
+            TypeAdapter<?> valueAdapter = gson.getAdapter(TypeToken.get(resolveTypeArgument(typeArgs, typeVars[2])));
+            @SuppressWarnings("unchecked")
+            TypeAdapter<T> adapter = (TypeAdapter<T>) new TableTypeAdapter<>(gson, rowKeyAdapter,
+                    columnKeyAdapter, valueAdapter).nullSafe();
+            return adapter;
         }
 
-        @Override
-        public Table<R, C, V> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
-            Type typeOfR;
-            Type typeOfC;
-            Type typeOfV;
-            { // CHECKSTYLE IGNORE THIS LINE
-                ParameterizedType parameterizedType = (ParameterizedType) typeOfT;
-                Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
-                typeOfR = actualTypeArguments[0];
-                typeOfC = actualTypeArguments[1];
-                typeOfV = actualTypeArguments[2];
-            } // CHECKSTYLE IGNORE THIS LINE
-            JsonObject tableJsonObject = json.getAsJsonObject();
-            String tableClazz = tableJsonObject.get("clazz").getAsString();
-            JsonArray rowKeysJsonArray = tableJsonObject.getAsJsonArray("rowKeys");
-            Map<Integer, R> rowIndexToKey = new HashMap<>();
-            for (JsonElement jsonElement : rowKeysJsonArray) {
-                R rowKey = context.deserialize(jsonElement, typeOfR);
-                rowIndexToKey.put(rowIndexToKey.size(), rowKey);
+        private static Type resolveTypeArgument(Map<TypeVariable<?>, Type> typeArgs, TypeVariable<?> typeVar) {
+            Type type = typeArgs == null ? null : typeArgs.get(typeVar);
+            // unresolvable type argument (e.g. raw Table), fall back to runtime type dispatch
+            return (type == null || type instanceof TypeVariable) ? Object.class : type;
+        }
+
+        private static class TableTypeAdapter<R, C, V> extends TypeAdapter<Table<R, C, V>> {
+            private final Gson gson;
+            private final TypeAdapter<R> rowKeyAdapter;
+            private final TypeAdapter<C> columnKeyAdapter;
+            private final TypeAdapter<V> valueAdapter;
+
+            @SuppressWarnings("unchecked")
+            TableTypeAdapter(Gson gson, TypeAdapter<?> rowKeyAdapter, TypeAdapter<?> columnKeyAdapter,
+                    TypeAdapter<?> valueAdapter) {
+                this.gson = gson;
+                this.rowKeyAdapter = (TypeAdapter<R>) rowKeyAdapter;
+                this.columnKeyAdapter = (TypeAdapter<C>) columnKeyAdapter;
+                this.valueAdapter = (TypeAdapter<V>) valueAdapter;
             }
-            JsonArray columnKeysJsonArray = tableJsonObject.getAsJsonArray("columnKeys");
-            Map<Integer, C> columnIndexToKey = new HashMap<>();
-            for (JsonElement jsonElement : columnKeysJsonArray) {
-                C columnKey = context.deserialize(jsonElement, typeOfC);
-                columnIndexToKey.put(columnIndexToKey.size(), columnKey);
+
+            @Override
+            public void write(JsonWriter out, Table<R, C, V> src) throws IOException {
+                out.beginObject();
+                out.name("clazz").value(src.getClass().getSimpleName());
+                out.name("rowKeys");
+                out.beginArray();
+                Map<R, Integer> rowKeyToIndex = new HashMap<>();
+                for (R rowKey : src.rowKeySet()) {
+                    rowKeyToIndex.put(rowKey, rowKeyToIndex.size());
+                    writeByRuntimeType(out, rowKey);
+                }
+                out.endArray();
+                out.name("columnKeys");
+                out.beginArray();
+                Map<C, Integer> columnKeyToIndex = new HashMap<>();
+                for (C columnKey : src.columnKeySet()) {
+                    columnKeyToIndex.put(columnKey, columnKeyToIndex.size());
+                    writeByRuntimeType(out, columnKey);
+                }
+                out.endArray();
+                out.name("cells");
+                out.beginArray();
+                for (Table.Cell<R, C, V> cell : src.cellSet()) {
+                    out.value((long) rowKeyToIndex.get(cell.getRowKey()));
+                    out.value((long) columnKeyToIndex.get(cell.getColumnKey()));
+                    writeByRuntimeType(out, cell.getValue());
+                }
+                out.endArray();
+                out.endObject();
             }
-            JsonArray cellsJsonArray = tableJsonObject.getAsJsonArray("cells");
-            Table<R, C, V> table = null;
-            switch (tableClazz) {
-                case "HashBasedTable":
-                    table = HashBasedTable.create();
-                    break;
-                default:
-                    Preconditions.checkState(false, "unknown guava table class: " + tableClazz);
-                    break;
+
+            // dispatch by runtime class, same as the tree mode JsonSerializationContext.serialize(src)
+            @SuppressWarnings("unchecked")
+            private void writeByRuntimeType(JsonWriter out, Object src) throws IOException {
+                TypeAdapter<Object> adapter = (TypeAdapter<Object>) gson.getAdapter(src.getClass());
+                adapter.write(out, src);
             }
-            for (int i = 0; i < cellsJsonArray.size(); i = i + 3) {
-                // format is [rowIndex, columnIndex, value]
-                int rowIndex = cellsJsonArray.get(i).getAsInt();
-                int columnIndex = cellsJsonArray.get(i + 1).getAsInt();
-                R rowKey = rowIndexToKey.get(rowIndex);
-                C columnKey = columnIndexToKey.get(columnIndex);
-                V value = context.deserialize(cellsJsonArray.get(i + 2), typeOfV);
-                table.put(rowKey, columnKey, value);
+
+            @Override
+            public Table<R, C, V> read(JsonReader in) throws IOException {
+                in.beginObject();
+                expectName(in, "clazz");
+                String tableClazz = in.nextString();
+                Table<R, C, V> table = null;
+                switch (tableClazz) {
+                    case "HashBasedTable":
+                        table = HashBasedTable.create();
+                        break;
+                    default:
+                        Preconditions.checkState(false, "unknown guava table class: " + tableClazz);
+                        break;
+                }
+                expectName(in, "rowKeys");
+                List<R> rowKeys = new ArrayList<>();
+                in.beginArray();
+                while (in.hasNext()) {
+                    rowKeys.add(rowKeyAdapter.read(in));
+                }
+                in.endArray();
+                expectName(in, "columnKeys");
+                List<C> columnKeys = new ArrayList<>();
+                in.beginArray();
+                while (in.hasNext()) {
+                    columnKeys.add(columnKeyAdapter.read(in));
+                }
+                in.endArray();
+                expectName(in, "cells");
+                in.beginArray();
+                // format is [rowIndex, columnIndex, value, rowIndex, columnIndex, value, ...]
+                while (in.hasNext()) {
+                    int rowIndex = in.nextInt();
+                    int columnIndex = in.nextInt();
+                    V value = valueAdapter.read(in);
+                    table.put(rowKeys.get(rowIndex), columnKeys.get(columnIndex), value);
+                }
+                in.endArray();
+                in.endObject();
+                return table;
             }
-            return table;
         }
     }
 
@@ -836,7 +880,7 @@ public class GsonUtils {
     }
 
     /*
-     * The json adapter for Guava Multimap.
+     * The streaming json adapter factory for Guava Multimap.
      * Current support:
      * 1. ArrayListMultimap
      * 2. HashMultimap
@@ -844,9 +888,17 @@ public class GsonUtils {
      * 4. LinkedHashMultimap
      *
      * The key and value classes of multi map should also be json serializable.
+     *
+     * serialize Multimap<K, V> as:
+     * {
+     * "clazz": "HashMultimap",
+     * "map": { ... the asMap() view of the multimap ... }
+     * }
+     *
+     * Same as GuavaTableTypeAdapterFactory, it works in streaming mode to avoid
+     * materializing the JsonElement DOM tree of the whole map.
      */
-    private static class GuavaMultimapAdapter<K, V>
-            implements JsonSerializer<Multimap<K, V>>, JsonDeserializer<Multimap<K, V>> {
+    private static class GuavaMultimapTypeAdapterFactory implements TypeAdapterFactory {
 
         private static final Type asMapReturnType = getAsMapMethod().getGenericReturnType();
 
@@ -863,49 +915,71 @@ public class GsonUtils {
         }
 
         @Override
-        public JsonElement serialize(Multimap<K, V> map, Type typeOfSrc, JsonSerializationContext context) {
-            JsonObject jsonObject = new JsonObject();
-            jsonObject.addProperty("clazz", map.getClass().getSimpleName());
-            Map<K, Collection<V>> asMap = map.asMap();
-            Type type = asMapType(typeOfSrc);
-            JsonElement jsonElement = context.serialize(asMap, type);
-            jsonObject.add("map", jsonElement);
-            return jsonObject;
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+            if (!Multimap.class.isAssignableFrom(typeToken.getRawType())) {
+                return null;
+            }
+            TypeAdapter<?> asMapAdapter = gson.getAdapter(TypeToken.get(asMapType(typeToken.getType())));
+            @SuppressWarnings("unchecked")
+            TypeAdapter<T> adapter = (TypeAdapter<T>) new MultimapTypeAdapter<>(asMapAdapter).nullSafe();
+            return adapter;
         }
 
-        @Override
-        public Multimap<K, V> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
-                throws JsonParseException {
-            JsonObject jsonObject = json.getAsJsonObject();
-            String clazz = jsonObject.get("clazz").getAsString();
+        private static class MultimapTypeAdapter<K, V> extends TypeAdapter<Multimap<K, V>> {
+            private final TypeAdapter<Map<K, Collection<V>>> asMapAdapter;
 
-            JsonElement mapElement = jsonObject.get("map");
-            Map<K, Collection<V>> asMap = context.deserialize(mapElement, asMapType(typeOfT));
-
-            Multimap<K, V> map = null;
-            switch (clazz) {
-                case "ArrayListMultimap":
-                    map = ArrayListMultimap.create();
-                    break;
-                case "HashMultimap":
-                    map = HashMultimap.create();
-                    break;
-                case "LinkedListMultimap":
-                    map = LinkedListMultimap.create();
-                    break;
-                case "LinkedHashMultimap":
-                    map = LinkedHashMultimap.create();
-                    break;
-                default:
-                    Preconditions.checkState(false, "unknown guava multi map class: " + clazz);
-                    break;
+            @SuppressWarnings("unchecked")
+            MultimapTypeAdapter(TypeAdapter<?> asMapAdapter) {
+                this.asMapAdapter = (TypeAdapter<Map<K, Collection<V>>>) asMapAdapter;
             }
 
-            for (Map.Entry<K, Collection<V>> entry : asMap.entrySet()) {
-                map.putAll(entry.getKey(), entry.getValue());
+            @Override
+            public void write(JsonWriter out, Multimap<K, V> src) throws IOException {
+                out.beginObject();
+                out.name("clazz").value(src.getClass().getSimpleName());
+                out.name("map");
+                asMapAdapter.write(out, src.asMap());
+                out.endObject();
             }
-            return map;
+
+            @Override
+            public Multimap<K, V> read(JsonReader in) throws IOException {
+                in.beginObject();
+                expectName(in, "clazz");
+                String clazz = in.nextString();
+                Multimap<K, V> map = null;
+                switch (clazz) {
+                    case "ArrayListMultimap":
+                        map = ArrayListMultimap.create();
+                        break;
+                    case "HashMultimap":
+                        map = HashMultimap.create();
+                        break;
+                    case "LinkedListMultimap":
+                        map = LinkedListMultimap.create();
+                        break;
+                    case "LinkedHashMultimap":
+                        map = LinkedHashMultimap.create();
+                        break;
+                    default:
+                        Preconditions.checkState(false, "unknown guava multi map class: " + clazz);
+                        break;
+                }
+                expectName(in, "map");
+                Map<K, Collection<V>> asMap = asMapAdapter.read(in);
+                in.endObject();
+                for (Map.Entry<K, Collection<V>> entry : asMap.entrySet()) {
+                    map.putAll(entry.getKey(), entry.getValue());
+                }
+                return map;
+            }
         }
+    }
+
+    private static void expectName(JsonReader in, String expectedName) throws IOException {
+        String name = in.nextName();
+        Preconditions.checkState(expectedName.equals(name),
+                "expect json field '%s' but found '%s'", expectedName, name);
     }
 
     private static class AtomicBooleanAdapter

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -581,9 +581,13 @@ public class GsonUtils {
             .registerSubtype(S3FileSystem.class, S3FileSystem.class.getSimpleName())
             .registerSubtype(AzureFileSystem.class, AzureFileSystem.class.getSimpleName());
 
+    // streaming dispatch avoids materializing the whole job as a JsonElement DOM tree:
+    // a single backup/restore job journal entry can be tens of MB and its DOM costs
+    // dozens of times more transient heap than the serialized bytes
     private static RuntimeTypeAdapterFactory<org.apache.doris.backup.AbstractJob>
             jobBackupTypeAdapterFactory
                     = RuntimeTypeAdapterFactory.of(org.apache.doris.backup.AbstractJob.class, "clazz")
+                    .withStreamingDispatch()
                     .registerSubtype(BackupJob.class, BackupJob.class.getSimpleName())
                     .registerSubtype(RestoreJob.class, RestoreJob.class.getSimpleName())
                     .registerSubtype(CloudRestoreJob.class, CloudRestoreJob.class.getSimpleName());

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -720,6 +720,11 @@ public class GsonUtils {
      * costs tens of times more memory than the serialized bytes and easily causes FE heap
      * spikes. The streaming TypeAdapter writes to JsonWriter and reads from JsonReader
      * directly, without building the DOM.
+     *
+     * The field order (clazz, rowKeys, columnKeys, cells / clazz, map) is part of the
+     * format contract: the streaming reader expects this exact order and fails fast on
+     * mismatch. This is safe because all Doris-generated journals/images (both the legacy
+     * tree mode adapter and this adapter) always emit fields in this order.
      */
     private static class GuavaTableTypeAdapterFactory implements TypeAdapterFactory {
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -232,6 +232,7 @@ import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -615,9 +616,9 @@ public class GsonUtils {
                     new HiddenAnnotationExclusionStrategy()).serializeSpecialFloatingPointValues()
             .enableComplexMapKeySerialization()
             .addReflectionAccessFilter(ReflectionAccessFilter.BLOCK_INACCESSIBLE_JAVA)
-            .registerTypeAdapterFactory(new GuavaTableTypeAdapterFactory())
+            .registerTypeHierarchyAdapter(Table.class, new GuavaTableAdapter())
             // .registerTypeHierarchyAdapter(Expr.class, new ExprAdapter())
-            .registerTypeAdapterFactory(new GuavaMultimapTypeAdapterFactory())
+            .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
             .registerTypeAdapterFactory(new PostProcessTypeAdapterFactory())
             .registerTypeAdapterFactory(new PreProcessTypeAdapterFactory())
             .registerTypeAdapterFactory(exprAdapterFactory)
@@ -693,40 +694,132 @@ public class GsonUtils {
 
     /*
      *
-     * The streaming json adapter factory for Guava Table.
+     * The json adapter for Guava Table.
      * Current support:
      * 1. HashBasedTable
      *
      * The RowKey, ColumnKey and Value classes in Table should also be serializable.
      *
-     * serialize Table<R, C, V> as:
-     * {
-     * "clazz": "HashBasedTable",
-     * "rowKeys": [ "rowKey1", "rowKey2", ...],
-     * "columnKeys": [ "colKey1", "colKey2", ...],
-     * "cells" : [0, 0, value1, 0, 1, value2, ...]
-     * }
+     * What is Adapter and Why we should implement it?
      *
-     * the [0, 0] .. in cells are the indexes of rowKeys array and columnKeys array.
-     * This serialization method can reduce the size of json string because it
-     * replace the same row key
-     * and column key to integer.
-     *
-     * Why TypeAdapterFactory instead of JsonSerializer/JsonDeserializer?
-     *
-     * JsonSerializer/JsonDeserializer works in tree mode, which materializes the whole
-     * JsonElement DOM tree in memory before writing (or after parsing). For large tables
-     * (e.g. RestoreJob.snapshotInfos with tens of thousands of tablets), the transient DOM
-     * costs tens of times more memory than the serialized bytes and easily causes FE heap
-     * spikes. The streaming TypeAdapter writes to JsonWriter and reads from JsonReader
-     * directly, without building the DOM.
-     *
-     * The field order (clazz, rowKeys, columnKeys, cells / clazz, map) is part of the
-     * format contract: the streaming reader expects this exact order and fails fast on
-     * mismatch. This is safe because all Doris-generated journals/images (both the legacy
-     * tree mode adapter and this adapter) always emit fields in this order.
+     * Adapter is mainly used to provide serialization and deserialization methods for some complex classes.
+     * Complex classes here usually refer to classes that are complex and cannot be modified.
+     * These classes mainly include third-party library classes or some inherited classes.
      */
-    private static class GuavaTableTypeAdapterFactory implements TypeAdapterFactory {
+    private static class GuavaTableAdapter<R, C, V>
+            implements JsonSerializer<Table<R, C, V>>, JsonDeserializer<Table<R, C, V>> {
+        /*
+         * serialize Table<R, C, V> as:
+         * {
+         * "rowKeys": [ "rowKey1", "rowKey2", ...],
+         * "columnKeys": [ "colKey1", "colKey2", ...],
+         * "cells" : [[0, 0, value1], [0, 1, value2], ...]
+         * }
+         *
+         * the [0, 0] .. in cells are the indexes of rowKeys array and columnKeys array.
+         * This serialization method can reduce the size of json string because it
+         * replace the same row key
+         * and column key to integer.
+         */
+        @Override
+        public JsonElement serialize(Table<R, C, V> src, Type typeOfSrc, JsonSerializationContext context) {
+            JsonArray rowKeysJsonArray = new JsonArray();
+            Map<R, Integer> rowKeyToIndex = new HashMap<>();
+            for (R rowKey : src.rowKeySet()) {
+                rowKeyToIndex.put(rowKey, rowKeyToIndex.size());
+                rowKeysJsonArray.add(context.serialize(rowKey));
+            }
+            JsonArray columnKeysJsonArray = new JsonArray();
+            Map<C, Integer> columnKeyToIndex = new HashMap<>();
+            for (C columnKey : src.columnKeySet()) {
+                columnKeyToIndex.put(columnKey, columnKeyToIndex.size());
+                columnKeysJsonArray.add(context.serialize(columnKey));
+            }
+            JsonArray cellsJsonArray = new JsonArray();
+            for (Table.Cell<R, C, V> cell : src.cellSet()) {
+                int rowIndex = rowKeyToIndex.get(cell.getRowKey());
+                int columnIndex = columnKeyToIndex.get(cell.getColumnKey());
+                cellsJsonArray.add(rowIndex);
+                cellsJsonArray.add(columnIndex);
+                cellsJsonArray.add(context.serialize(cell.getValue()));
+            }
+            JsonObject tableJsonObject = new JsonObject();
+            tableJsonObject.addProperty("clazz", src.getClass().getSimpleName());
+            tableJsonObject.add("rowKeys", rowKeysJsonArray);
+            tableJsonObject.add("columnKeys", columnKeysJsonArray);
+            tableJsonObject.add("cells", cellsJsonArray);
+            return tableJsonObject;
+        }
+
+        @Override
+        public Table<R, C, V> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+            Type typeOfR;
+            Type typeOfC;
+            Type typeOfV;
+            { // CHECKSTYLE IGNORE THIS LINE
+                ParameterizedType parameterizedType = (ParameterizedType) typeOfT;
+                Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+                typeOfR = actualTypeArguments[0];
+                typeOfC = actualTypeArguments[1];
+                typeOfV = actualTypeArguments[2];
+            } // CHECKSTYLE IGNORE THIS LINE
+            JsonObject tableJsonObject = json.getAsJsonObject();
+            String tableClazz = tableJsonObject.get("clazz").getAsString();
+            JsonArray rowKeysJsonArray = tableJsonObject.getAsJsonArray("rowKeys");
+            Map<Integer, R> rowIndexToKey = new HashMap<>();
+            for (JsonElement jsonElement : rowKeysJsonArray) {
+                R rowKey = context.deserialize(jsonElement, typeOfR);
+                rowIndexToKey.put(rowIndexToKey.size(), rowKey);
+            }
+            JsonArray columnKeysJsonArray = tableJsonObject.getAsJsonArray("columnKeys");
+            Map<Integer, C> columnIndexToKey = new HashMap<>();
+            for (JsonElement jsonElement : columnKeysJsonArray) {
+                C columnKey = context.deserialize(jsonElement, typeOfC);
+                columnIndexToKey.put(columnIndexToKey.size(), columnKey);
+            }
+            JsonArray cellsJsonArray = tableJsonObject.getAsJsonArray("cells");
+            Table<R, C, V> table = null;
+            switch (tableClazz) {
+                case "HashBasedTable":
+                    table = HashBasedTable.create();
+                    break;
+                default:
+                    Preconditions.checkState(false, "unknown guava table class: " + tableClazz);
+                    break;
+            }
+            for (int i = 0; i < cellsJsonArray.size(); i = i + 3) {
+                // format is [rowIndex, columnIndex, value]
+                int rowIndex = cellsJsonArray.get(i).getAsInt();
+                int columnIndex = cellsJsonArray.get(i + 1).getAsInt();
+                R rowKey = rowIndexToKey.get(rowIndex);
+                C columnKey = columnIndexToKey.get(columnIndex);
+                V value = context.deserialize(cellsJsonArray.get(i + 2), typeOfV);
+                table.put(rowKey, columnKey, value);
+            }
+            return table;
+        }
+    }
+
+    /*
+     * The streaming counterpart of GuavaTableAdapter, producing byte-identical json.
+     *
+     * GuavaTableAdapter works in tree mode, which materializes the whole JsonElement DOM
+     * tree in memory before writing (or after parsing). For large tables (e.g.
+     * RestoreJob.snapshotInfos with tens of thousands of tablets), the transient DOM costs
+     * tens of times more memory than the serialized bytes and easily causes FE heap spikes.
+     * The streaming TypeAdapter writes to JsonWriter and reads from JsonReader directly,
+     * without building the DOM.
+     *
+     * It is applied per-field via the @JsonAdapter annotation (currently only on the large
+     * Table fields of RestoreJob) instead of being registered globally, to keep the blast
+     * radius of the behavior change minimal.
+     *
+     * The field order (clazz, rowKeys, columnKeys, cells) is part of the format contract:
+     * the streaming reader expects this exact order and fails fast on mismatch. This is
+     * safe because all Doris-generated journals/images (both GuavaTableAdapter and this
+     * adapter) always emit fields in this order.
+     */
+    public static class GuavaTableTypeAdapterFactory implements TypeAdapterFactory {
         @Override
         public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
             if (!Table.class.isAssignableFrom(typeToken.getRawType())) {
@@ -885,7 +978,7 @@ public class GsonUtils {
     }
 
     /*
-     * The streaming json adapter factory for Guava Multimap.
+     * The json adapter for Guava Multimap.
      * Current support:
      * 1. ArrayListMultimap
      * 2. HashMultimap
@@ -893,17 +986,9 @@ public class GsonUtils {
      * 4. LinkedHashMultimap
      *
      * The key and value classes of multi map should also be json serializable.
-     *
-     * serialize Multimap<K, V> as:
-     * {
-     * "clazz": "HashMultimap",
-     * "map": { ... the asMap() view of the multimap ... }
-     * }
-     *
-     * Same as GuavaTableTypeAdapterFactory, it works in streaming mode to avoid
-     * materializing the JsonElement DOM tree of the whole map.
      */
-    private static class GuavaMultimapTypeAdapterFactory implements TypeAdapterFactory {
+    private static class GuavaMultimapAdapter<K, V>
+            implements JsonSerializer<Multimap<K, V>>, JsonDeserializer<Multimap<K, V>> {
 
         private static final Type asMapReturnType = getAsMapMethod().getGenericReturnType();
 
@@ -920,64 +1005,48 @@ public class GsonUtils {
         }
 
         @Override
-        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
-            if (!Multimap.class.isAssignableFrom(typeToken.getRawType())) {
-                return null;
-            }
-            TypeAdapter<?> asMapAdapter = gson.getAdapter(TypeToken.get(asMapType(typeToken.getType())));
-            @SuppressWarnings("unchecked")
-            TypeAdapter<T> adapter = (TypeAdapter<T>) new MultimapTypeAdapter<>(asMapAdapter).nullSafe();
-            return adapter;
+        public JsonElement serialize(Multimap<K, V> map, Type typeOfSrc, JsonSerializationContext context) {
+            JsonObject jsonObject = new JsonObject();
+            jsonObject.addProperty("clazz", map.getClass().getSimpleName());
+            Map<K, Collection<V>> asMap = map.asMap();
+            Type type = asMapType(typeOfSrc);
+            JsonElement jsonElement = context.serialize(asMap, type);
+            jsonObject.add("map", jsonElement);
+            return jsonObject;
         }
 
-        private static class MultimapTypeAdapter<K, V> extends TypeAdapter<Multimap<K, V>> {
-            private final TypeAdapter<Map<K, Collection<V>>> asMapAdapter;
+        @Override
+        public Multimap<K, V> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            JsonObject jsonObject = json.getAsJsonObject();
+            String clazz = jsonObject.get("clazz").getAsString();
 
-            @SuppressWarnings("unchecked")
-            MultimapTypeAdapter(TypeAdapter<?> asMapAdapter) {
-                this.asMapAdapter = (TypeAdapter<Map<K, Collection<V>>>) asMapAdapter;
+            JsonElement mapElement = jsonObject.get("map");
+            Map<K, Collection<V>> asMap = context.deserialize(mapElement, asMapType(typeOfT));
+
+            Multimap<K, V> map = null;
+            switch (clazz) {
+                case "ArrayListMultimap":
+                    map = ArrayListMultimap.create();
+                    break;
+                case "HashMultimap":
+                    map = HashMultimap.create();
+                    break;
+                case "LinkedListMultimap":
+                    map = LinkedListMultimap.create();
+                    break;
+                case "LinkedHashMultimap":
+                    map = LinkedHashMultimap.create();
+                    break;
+                default:
+                    Preconditions.checkState(false, "unknown guava multi map class: " + clazz);
+                    break;
             }
 
-            @Override
-            public void write(JsonWriter out, Multimap<K, V> src) throws IOException {
-                out.beginObject();
-                out.name("clazz").value(src.getClass().getSimpleName());
-                out.name("map");
-                asMapAdapter.write(out, src.asMap());
-                out.endObject();
+            for (Map.Entry<K, Collection<V>> entry : asMap.entrySet()) {
+                map.putAll(entry.getKey(), entry.getValue());
             }
-
-            @Override
-            public Multimap<K, V> read(JsonReader in) throws IOException {
-                in.beginObject();
-                expectName(in, "clazz");
-                String clazz = in.nextString();
-                Multimap<K, V> map = null;
-                switch (clazz) {
-                    case "ArrayListMultimap":
-                        map = ArrayListMultimap.create();
-                        break;
-                    case "HashMultimap":
-                        map = HashMultimap.create();
-                        break;
-                    case "LinkedListMultimap":
-                        map = LinkedListMultimap.create();
-                        break;
-                    case "LinkedHashMultimap":
-                        map = LinkedHashMultimap.create();
-                        break;
-                    default:
-                        Preconditions.checkState(false, "unknown guava multi map class: " + clazz);
-                        break;
-                }
-                expectName(in, "map");
-                Map<K, Collection<V>> asMap = asMapAdapter.read(in);
-                in.endObject();
-                for (Map.Entry<K, Collection<V>> entry : asMap.entrySet()) {
-                    map.putAll(entry.getKey(), entry.getValue());
-                }
-                return map;
-            }
+            return map;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/RuntimeTypeAdapterFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/RuntimeTypeAdapterFactory.java
@@ -26,12 +26,16 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.internal.JsonReaderInternalAccess;
 import com.google.gson.internal.Streams;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
 import java.lang.reflect.Modifier;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -186,6 +190,16 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
 
     private final boolean maintainType;
     private Class<? extends T> defaultType = null;
+    // When enabled, write/read dispatch streams directly to/from the underlying
+    // JsonWriter/JsonReader instead of materializing the whole object as a
+    // JsonElement DOM tree. The produced bytes are identical to the tree mode
+    // (the type field is still emitted as the first field). This matters for
+    // huge objects like backup/restore jobs whose single journal entry can be
+    // tens of MB: tree mode keeps a DOM dozens of times larger than the json
+    // alive during write/read. Streaming read requires the type field to be the
+    // first field, which holds for all Doris-generated journals/images since
+    // tree mode always emits it first.
+    private boolean streamingDispatch = false;
 
     private RuntimeTypeAdapterFactory(Class<?> baseType, String typeFieldName, boolean maintainType) {
         if (typeFieldName == null || baseType == null) {
@@ -255,6 +269,19 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
     }
 
     /**
+     * Enables streaming dispatch. Only valid for factories without
+     * {@code maintainType} and without a default subtype, where the type field
+     * is guaranteed to be the first json field.
+     */
+    public RuntimeTypeAdapterFactory<T> withStreamingDispatch() {
+        if (maintainType) {
+            throw new IllegalStateException("streaming dispatch does not support maintainType");
+        }
+        this.streamingDispatch = true;
+        return this;
+    }
+
+    /**
      * Registers {@code type} for using when label not found
      */
     public RuntimeTypeAdapterFactory<T> registerDefaultSubtype(Class<? extends T> type) {
@@ -303,6 +330,9 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
         return new TypeAdapter<R>() {
             @Override
             public R read(JsonReader in) throws IOException {
+                if (streamingDispatch && defaultDelegate == null && in.peek() == JsonToken.BEGIN_OBJECT) {
+                    return readStreaming(in);
+                }
                 JsonElement jsonElement = Streams.parse(in);
                 JsonElement labelJsonElement;
                 if (maintainType) {
@@ -330,6 +360,28 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
                 return delegate.fromJsonTree(jsonElement);
             }
 
+            private R readStreaming(JsonReader in) throws IOException {
+                in.beginObject();
+                if (!in.hasNext()) {
+                    throw new JsonParseException("cannot deserialize " + baseType
+                            + " because it does not define a field named " + typeFieldName);
+                }
+                String firstName = in.nextName();
+                if (!typeFieldName.equals(firstName)) {
+                    throw new JsonParseException("cannot deserialize " + baseType + " in streaming mode because"
+                            + " the first field is '" + firstName + "' instead of '" + typeFieldName + "'");
+                }
+                String label = in.nextString();
+                @SuppressWarnings("unchecked") // registration requires that subtype extends T
+                TypeAdapter<R> delegate = (TypeAdapter<R>) labelToDelegate.get(label);
+                if (delegate == null) {
+                    throw new JsonParseException("cannot deserialize " + baseType + " subtype named " + label
+                            + "; did you forget to register a subtype?");
+                }
+                // the type field has been consumed, equivalent to remove(typeFieldName) in tree mode
+                return delegate.read(new EnteredObjectJsonReader(in));
+            }
+
             @Override
             public void write(JsonWriter out, R value) throws IOException {
                 Class<?> srcType = value.getClass();
@@ -339,6 +391,10 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
                 if (delegate == null) {
                     throw new JsonParseException(
                             "cannot serialize " + srcType.getName() + "; did you forget to register a subtype?");
+                }
+                if (streamingDispatch) {
+                    delegate.write(new TypeFieldInjectingJsonWriter(out, typeFieldName, label, srcType), value);
+                    return;
                 }
                 JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
 
@@ -361,5 +417,327 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
                 Streams.write(clone, out);
             }
         }.nullSafe();
+    }
+
+    /*
+     * A pass-through JsonWriter which injects '"typeFieldName": "label"' right after the
+     * first beginObject(), producing the same bytes as the tree mode which clones the
+     * JsonObject and puts the type field first.
+     */
+    private static final class TypeFieldInjectingJsonWriter extends JsonWriter {
+        private static final Writer UNUSED_WRITER = new Writer() {
+            @Override
+            public void write(char[] buffer, int offset, int counter) {
+                throw new AssertionError("all methods should be forwarded to the delegate writer");
+            }
+
+            @Override
+            public void flush() {
+                throw new AssertionError();
+            }
+
+            @Override
+            public void close() {
+                throw new AssertionError();
+            }
+        };
+
+        private final JsonWriter delegate;
+        private final String typeFieldName;
+        private final String label;
+        private final Class<?> srcType;
+        // depth of nested objects/arrays, used to detect the top level
+        private int depth = 0;
+        private boolean typeFieldWritten = false;
+
+        TypeFieldInjectingJsonWriter(JsonWriter delegate, String typeFieldName, String label, Class<?> srcType) {
+            super(UNUSED_WRITER);
+            this.delegate = delegate;
+            this.typeFieldName = typeFieldName;
+            this.label = label;
+            this.srcType = srcType;
+            // these getters are final and cannot be forwarded, sync the flags instead
+            setLenient(delegate.isLenient());
+            setHtmlSafe(delegate.isHtmlSafe());
+            setSerializeNulls(delegate.getSerializeNulls());
+        }
+
+        private void requireInsideObject() {
+            if (depth == 0) {
+                throw new JsonParseException("cannot serialize " + srcType.getName()
+                        + " in streaming mode because it is not serialized as a json object");
+            }
+        }
+
+        @Override
+        public JsonWriter beginObject() throws IOException {
+            delegate.beginObject();
+            depth++;
+            if (!typeFieldWritten) {
+                typeFieldWritten = true;
+                delegate.name(typeFieldName);
+                delegate.value(label);
+            }
+            return this;
+        }
+
+        @Override
+        public JsonWriter endObject() throws IOException {
+            delegate.endObject();
+            depth--;
+            return this;
+        }
+
+        @Override
+        public JsonWriter beginArray() throws IOException {
+            requireInsideObject();
+            delegate.beginArray();
+            depth++;
+            return this;
+        }
+
+        @Override
+        public JsonWriter endArray() throws IOException {
+            delegate.endArray();
+            depth--;
+            return this;
+        }
+
+        @Override
+        public JsonWriter name(String name) throws IOException {
+            if (depth == 1 && typeFieldName.equals(name)) {
+                throw new JsonParseException("cannot serialize " + srcType.getName()
+                        + " because it already defines a field named " + typeFieldName);
+            }
+            delegate.name(name);
+            return this;
+        }
+
+        @Override
+        public JsonWriter value(String value) throws IOException {
+            requireInsideObject();
+            delegate.value(value);
+            return this;
+        }
+
+        @Override
+        public JsonWriter jsonValue(String value) throws IOException {
+            requireInsideObject();
+            delegate.jsonValue(value);
+            return this;
+        }
+
+        @Override
+        public JsonWriter nullValue() throws IOException {
+            requireInsideObject();
+            delegate.nullValue();
+            return this;
+        }
+
+        @Override
+        public JsonWriter value(boolean value) throws IOException {
+            requireInsideObject();
+            delegate.value(value);
+            return this;
+        }
+
+        @Override
+        public JsonWriter value(Boolean value) throws IOException {
+            requireInsideObject();
+            delegate.value(value);
+            return this;
+        }
+
+        @Override
+        public JsonWriter value(float value) throws IOException {
+            requireInsideObject();
+            delegate.value(value);
+            return this;
+        }
+
+        @Override
+        public JsonWriter value(double value) throws IOException {
+            requireInsideObject();
+            delegate.value(value);
+            return this;
+        }
+
+        @Override
+        public JsonWriter value(long value) throws IOException {
+            requireInsideObject();
+            delegate.value(value);
+            return this;
+        }
+
+        @Override
+        public JsonWriter value(Number value) throws IOException {
+            requireInsideObject();
+            delegate.value(value);
+            return this;
+        }
+
+        @Override
+        public boolean isLenient() {
+            return delegate.isLenient();
+        }
+
+        @Override
+        public void flush() throws IOException {
+            delegate.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+    }
+
+    /*
+     * A pass-through JsonReader for a stream whose top level BEGIN_OBJECT (and the type
+     * field) has already been consumed by readStreaming(): the first beginObject() call
+     * is a no-op, everything else is forwarded.
+     */
+    private static final class EnteredObjectJsonReader extends JsonReader {
+        private static final Reader UNUSED_READER = new Reader() {
+            @Override
+            public int read(char[] buffer, int offset, int count) {
+                throw new AssertionError("all methods should be forwarded to the delegate reader");
+            }
+
+            @Override
+            public void close() {
+                throw new AssertionError();
+            }
+        };
+
+        static {
+            // Gson's MapTypeAdapterFactory promotes a pending map key from NAME to VALUE
+            // through this global hook, whose default implementation manipulates the
+            // package-private state of the passed JsonReader directly instead of going
+            // through the public methods. For a pass-through wrapper like
+            // EnteredObjectJsonReader, the state lives in the delegate, so the hook must
+            // be applied to the delegate. Replace the hook once with an unwrapping
+            // version; behavior for all other JsonReader instances is unchanged.
+            // (Initializing this class triggers the JsonReader static initializer first,
+            // so INSTANCE is already the Gson built-in implementation here.)
+            final JsonReaderInternalAccess gsonBuiltin = JsonReaderInternalAccess.INSTANCE;
+            JsonReaderInternalAccess.INSTANCE = new JsonReaderInternalAccess() {
+                @Override
+                public void promoteNameToValue(JsonReader reader) throws IOException {
+                    while (reader instanceof EnteredObjectJsonReader) {
+                        reader = ((EnteredObjectJsonReader) reader).delegate;
+                    }
+                    gsonBuiltin.promoteNameToValue(reader);
+                }
+            };
+        }
+
+        private final JsonReader delegate;
+        private boolean topObjectEntered = false;
+
+        EnteredObjectJsonReader(JsonReader delegate) {
+            super(UNUSED_READER);
+            this.delegate = delegate;
+            // isLenient() is final and cannot be forwarded, sync the flag instead
+            setLenient(delegate.isLenient());
+        }
+
+        @Override
+        public void beginObject() throws IOException {
+            if (!topObjectEntered) {
+                // the top level BEGIN_OBJECT has already been consumed
+                topObjectEntered = true;
+                return;
+            }
+            delegate.beginObject();
+        }
+
+        @Override
+        public JsonToken peek() throws IOException {
+            if (!topObjectEntered) {
+                return JsonToken.BEGIN_OBJECT;
+            }
+            return delegate.peek();
+        }
+
+        @Override
+        public void endObject() throws IOException {
+            delegate.endObject();
+        }
+
+        @Override
+        public void beginArray() throws IOException {
+            delegate.beginArray();
+        }
+
+        @Override
+        public void endArray() throws IOException {
+            delegate.endArray();
+        }
+
+        @Override
+        public boolean hasNext() throws IOException {
+            return delegate.hasNext();
+        }
+
+        @Override
+        public String nextName() throws IOException {
+            return delegate.nextName();
+        }
+
+        @Override
+        public String nextString() throws IOException {
+            return delegate.nextString();
+        }
+
+        @Override
+        public boolean nextBoolean() throws IOException {
+            return delegate.nextBoolean();
+        }
+
+        @Override
+        public void nextNull() throws IOException {
+            delegate.nextNull();
+        }
+
+        @Override
+        public double nextDouble() throws IOException {
+            return delegate.nextDouble();
+        }
+
+        @Override
+        public long nextLong() throws IOException {
+            return delegate.nextLong();
+        }
+
+        @Override
+        public int nextInt() throws IOException {
+            return delegate.nextInt();
+        }
+
+        @Override
+        public void skipValue() throws IOException {
+            delegate.skipValue();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public String getPath() {
+            return delegate.getPath();
+        }
+
+        @Override
+        public String getPreviousPath() {
+            return delegate.getPreviousPath();
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/RuntimeTypeAdapterFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/RuntimeTypeAdapterFactory.java
@@ -277,6 +277,11 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
         if (maintainType) {
             throw new IllegalStateException("streaming dispatch does not support maintainType");
         }
+        // Install the JsonReaderInternalAccess hook now, i.e. inside the caller's
+        // (single-threaded) static initialization window such as GsonUtils class init.
+        // The hook field is a plain non-volatile static, so installing it lazily on
+        // the first streaming read could in theory be invisible to other threads.
+        EnteredObjectJsonReader.ensureInternalAccessHookInstalled();
         this.streamingDispatch = true;
         return this;
     }
@@ -630,6 +635,13 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
                     gsonBuiltin.promoteNameToValue(reader);
                 }
             };
+        }
+
+        /**
+         * Triggers class initialization; the static block above installs the hook
+         * exactly once under the JVM class-init lock.
+         */
+        static void ensureInternalAccessHookInstalled() {
         }
 
         private final JsonReader delegate;

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
@@ -428,6 +428,11 @@ public class SchemaChangeJobV2Test {
         Map<Long, SchemaVersionAndHash> indexSchemaVersionAndHashMap = Maps.newHashMap();
         indexSchemaVersionAndHashMap.put(Long.valueOf(1000), new SchemaVersionAndHash(10, 20));
         Deencapsulation.setField(schemaChangeJobV2, "indexSchemaVersionAndHashMap", indexSchemaVersionAndHashMap);
+        // populate the two Guava Table fields, to cover the streaming Table adapter
+        // with real metadata objects (MaterializedIndex value, Map value)
+        schemaChangeJobV2.addTabletIdMap(2000L, 3000L, 4001L, 5001L);
+        schemaChangeJobV2.addTabletIdMap(2000L, 3000L, 4002L, 5002L);
+        schemaChangeJobV2.addPartitionShadowIndex(2000L, 3000L, new MaterializedIndex(3000L, IndexState.SHADOW));
 
         // write schema change job
         schemaChangeJobV2.write(out);
@@ -445,8 +450,17 @@ public class SchemaChangeJobV2Test {
         Assert.assertEquals(AlterJobV2.JobState.FINISHED, result.getJobState());
         Assert.assertEquals(TStorageFormat.V2, Deencapsulation.getField(result, "storageFormat"));
 
-        Assert.assertNotNull(Deencapsulation.getField(result, "partitionIndexMap"));
-        Assert.assertNotNull(Deencapsulation.getField(result, "partitionIndexTabletMap"));
+        com.google.common.collect.Table<Long, Long, MaterializedIndex> partitionIndexMap
+                = Deencapsulation.getField(result, "partitionIndexMap");
+        Assert.assertEquals(1, partitionIndexMap.size());
+        Assert.assertEquals(3000L, partitionIndexMap.get(2000L, 3000L).getId());
+        Assert.assertEquals(IndexState.SHADOW, partitionIndexMap.get(2000L, 3000L).getState());
+        com.google.common.collect.Table<Long, Long, Map<Long, Long>> partitionIndexTabletMap
+                = Deencapsulation.getField(result, "partitionIndexTabletMap");
+        Assert.assertEquals(1, partitionIndexTabletMap.size());
+        Map<Long, Long> tabletMap = partitionIndexTabletMap.get(2000L, 3000L);
+        Assert.assertEquals(Long.valueOf(5001L), tabletMap.get(4001L));
+        Assert.assertEquals(Long.valueOf(5002L), tabletMap.get(4002L));
 
         Map<Long, SchemaVersionAndHash> map = Deencapsulation.getField(result, "indexSchemaVersionAndHashMap");
         Assert.assertEquals(10, map.get(1000L).schemaVersion);

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
@@ -293,6 +293,18 @@ public class RestoreJobTest {
 
     @Test
     public void testSerialization() throws IOException, AnalysisException {
+        // populate the Guava Table fields with non-trivial content, to cover the
+        // streaming Table adapter with real metadata objects (SnapshotInfo values)
+        com.google.common.collect.Table<Long, Long, SnapshotInfo> snapshotInfos
+                = Deencapsulation.getField(job, "snapshotInfos");
+        snapshotInfos.put(10001L, 20001L, new SnapshotInfo(db.getId(), CatalogMocker.TEST_TBL2_ID, 30001L, 40001L,
+                10001L, 20001L, 1234, "/path/to/snapshot1", Lists.newArrayList("1.dat", "1.idx", "1.hdr")));
+        snapshotInfos.put(10002L, 20001L, new SnapshotInfo(db.getId(), CatalogMocker.TEST_TBL2_ID, 30001L, 40001L,
+                10002L, 20001L, 1234, "/path/to/snapshot2", Lists.newArrayList("2.dat")));
+        com.google.common.collect.Table<Long, Long, Long> restoredVersionInfo
+                = Deencapsulation.getField(job, "restoredVersionInfo");
+        restoredVersionInfo.put(CatalogMocker.TEST_TBL2_ID, 30001L, 99L);
+
         // 1. Write objects to file
         final Path path = Files.createTempFile("restoreJob", "tmp");
         DataOutputStream out = new DataOutputStream(Files.newOutputStream(path));
@@ -310,6 +322,18 @@ public class RestoreJobTest {
         Assert.assertEquals(job.getDbId(), job2.getDbId());
         Assert.assertEquals(job.getCreateTime(), job2.getCreateTime());
         Assert.assertEquals(job.getType(), job2.getType());
+
+        com.google.common.collect.Table<Long, Long, SnapshotInfo> readSnapshotInfos
+                = Deencapsulation.getField(job2, "snapshotInfos");
+        Assert.assertEquals(2, readSnapshotInfos.size());
+        SnapshotInfo info1 = readSnapshotInfos.get(10001L, 20001L);
+        Assert.assertEquals(CatalogMocker.TEST_TBL2_ID, info1.getTblId());
+        Assert.assertEquals("/path/to/snapshot1", info1.getPath());
+        Assert.assertEquals(Lists.newArrayList("1.dat", "1.idx", "1.hdr"), info1.getFiles());
+        Assert.assertEquals("2.dat", readSnapshotInfos.get(10002L, 20001L).getFiles().get(0));
+        com.google.common.collect.Table<Long, Long, Long> readRestoredVersionInfo
+                = Deencapsulation.getField(job2, "restoredVersionInfo");
+        Assert.assertEquals(Long.valueOf(99L), readRestoredVersionInfo.get(CatalogMocker.TEST_TBL2_ID, 30001L));
 
         // 3. delete files
         in.close();

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/gson/GsonSerializationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/gson/GsonSerializationTest.java
@@ -603,14 +603,23 @@ public class GsonSerializationTest {
         holder.tbl.put(1L, "col2", 20L);
         holder.tbl.put(2L, "col1", 30L);
 
+        Type tableType = new TypeToken<Table<Long, String, Long>>() {
+        }.getType();
         String streamingJson = GsonUtils.GSON.toJson(holder);
         // serializing the bare Table goes through the global tree mode GuavaTableAdapter
-        String legacyTableJson = GsonUtils.GSON.toJson(holder.tbl,
-                new TypeToken<Table<Long, String, Long>>() {
-                }.getType());
+        String legacyTableJson = GsonUtils.GSON.toJson(holder.tbl, tableType);
         Assert.assertEquals("{\"tbl\":" + legacyTableJson + "}", streamingJson);
 
-        StreamingTableHolder read = GsonUtils.GSON.fromJson(streamingJson, StreamingTableHolder.class);
+        // new-write-old-read: bytes produced by the streaming writer are parsed by the
+        // global tree mode GuavaTableAdapter, simulating rollback / rolling upgrade
+        String streamingTableJson = streamingJson.substring("{\"tbl\":".length(), streamingJson.length() - 1);
+        Table<Long, String, Long> oldRead = GsonUtils.GSON.fromJson(streamingTableJson, tableType);
+        Assert.assertEquals(holder.tbl, oldRead);
+
+        // old-write-new-read: bytes produced by the tree mode writer are parsed by the
+        // streaming reader of the @JsonAdapter field
+        StreamingTableHolder read = GsonUtils.GSON.fromJson("{\"tbl\":" + legacyTableJson + "}",
+                StreamingTableHolder.class);
         Assert.assertEquals(holder.tbl, read.tbl);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/gson/GsonSerializationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/gson/GsonSerializationTest.java
@@ -24,6 +24,8 @@ import org.apache.doris.persist.gson.GsonSerializationTest.Key.MyEnum;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -494,5 +496,84 @@ public class GsonSerializationTest {
         Multimap<Long, String> readMultimap = GsonUtils.GSON.fromJson(json, multimapType);
         Assert.assertEquals("ArrayListMultimap", readMultimap.getClass().getSimpleName());
         Assert.assertEquals(Lists.newArrayList("value1", "value2"), readMultimap.get(1L));
+    }
+
+    @Test
+    public void testGuavaTableMultiRowColJsonFormat() {
+        Type tableType = new TypeToken<Table<Long, String, Long>>() {
+        }.getType();
+
+        // HashBasedTable is backed by LinkedHashMap, iteration follows insertion order
+        Table<Long, String, Long> table = HashBasedTable.create();
+        table.put(1L, "col1", 10L);
+        table.put(1L, "col2", 20L);
+        table.put(2L, "col1", 30L);
+        String json = GsonUtils.GSON.toJson(table, tableType);
+        Assert.assertEquals("{\"clazz\":\"HashBasedTable\",\"rowKeys\":[1,2],\"columnKeys\":[\"col1\",\"col2\"],"
+                + "\"cells\":[0,0,10,0,1,20,1,0,30]}", json);
+
+        Table<Long, String, Long> readTable = GsonUtils.GSON.fromJson(json, tableType);
+        Assert.assertEquals(table, readTable);
+    }
+
+    @Test
+    public void testGuavaHashMultimapJsonFormat() {
+        Type multimapType = new TypeToken<Multimap<Long, String>>() {
+        }.getType();
+
+        Multimap<Long, String> multimap = HashMultimap.create();
+        multimap.put(1L, "value1");
+        String json = GsonUtils.GSON.toJson(multimap, multimapType);
+        Assert.assertEquals("{\"clazz\":\"HashMultimap\",\"map\":{\"1\":[\"value1\"]}}", json);
+
+        Multimap<Long, String> readMultimap = GsonUtils.GSON.fromJson(json, multimapType);
+        Assert.assertEquals("HashMultimap", readMultimap.getClass().getSimpleName());
+        Assert.assertEquals(multimap, readMultimap);
+    }
+
+    @Test
+    public void testGuavaLinkedMultimapJsonFormat() {
+        Type multimapType = new TypeToken<Multimap<Long, String>>() {
+        }.getType();
+
+        // LinkedHashMultimap preserves insertion order, so multi-entry exact assertion is stable
+        Multimap<Long, String> linkedHashMultimap = LinkedHashMultimap.create();
+        linkedHashMultimap.put(2L, "value2");
+        linkedHashMultimap.put(1L, "value1");
+        linkedHashMultimap.put(2L, "value3");
+        String json = GsonUtils.GSON.toJson(linkedHashMultimap, multimapType);
+        Assert.assertEquals("{\"clazz\":\"LinkedHashMultimap\",\"map\":{\"2\":[\"value2\",\"value3\"],"
+                + "\"1\":[\"value1\"]}}", json);
+        Multimap<Long, String> readMultimap = GsonUtils.GSON.fromJson(json, multimapType);
+        Assert.assertEquals("LinkedHashMultimap", readMultimap.getClass().getSimpleName());
+        Assert.assertEquals(linkedHashMultimap, readMultimap);
+
+        Multimap<Long, String> linkedListMultimap = LinkedListMultimap.create();
+        linkedListMultimap.put(1L, "value1");
+        linkedListMultimap.put(1L, "value1");
+        json = GsonUtils.GSON.toJson(linkedListMultimap, multimapType);
+        Assert.assertEquals("{\"clazz\":\"LinkedListMultimap\",\"map\":{\"1\":[\"value1\",\"value1\"]}}", json);
+        readMultimap = GsonUtils.GSON.fromJson(json, multimapType);
+        Assert.assertEquals("LinkedListMultimap", readMultimap.getClass().getSimpleName());
+        Assert.assertEquals(linkedListMultimap, readMultimap);
+    }
+
+    /*
+     * Multimap with a complex (non-primitive) key goes through the array-of-pairs format of
+     * enableComplexMapKeySerialization, same as ColocateTableIndex.group2Tables (GroupId key).
+     */
+    @Test
+    public void testGuavaMultimapComplexKeyJsonFormat() {
+        Type multimapType = new TypeToken<Multimap<Key, Long>>() {
+        }.getType();
+
+        Multimap<Key, Long> multimap = HashMultimap.create();
+        multimap.put(new Key(MyEnum.TYPE_A, "key1"), 1L);
+        String json = GsonUtils.GSON.toJson(multimap, multimapType);
+        Assert.assertEquals("{\"clazz\":\"HashMultimap\",\"map\":[[{\"type\":\"TYPE_A\",\"value\":\"key1\"},[1]]]}",
+                json);
+
+        Multimap<Key, Long> readMultimap = GsonUtils.GSON.fromJson(json, multimapType);
+        Assert.assertEquals(multimap, readMultimap);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/gson/GsonSerializationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/gson/GsonSerializationTest.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import org.junit.After;
@@ -435,8 +436,9 @@ public class GsonSerializationTest {
     }
 
     /*
-     * The json format of Guava Table must be byte-compatible with the legacy tree mode
-     * GuavaTableAdapter, so that old journals can be replayed and rolling upgrade is safe.
+     * Pin the json format of the tree mode GuavaTableAdapter (registered globally).
+     * The streaming GuavaTableTypeAdapterFactory must produce byte-identical json,
+     * so that old journals can be replayed and rolling upgrade is safe.
      */
     @Test
     public void testGuavaTableJsonFormat() {
@@ -479,8 +481,7 @@ public class GsonSerializationTest {
     }
 
     /*
-     * The json format of Guava Multimap must be byte-compatible with the legacy tree mode
-     * GuavaMultimapAdapter.
+     * Pin the json format of the tree mode GuavaMultimapAdapter (registered globally).
      */
     @Test
     public void testGuavaMultimapJsonFormat() {
@@ -575,5 +576,58 @@ public class GsonSerializationTest {
 
         Multimap<Key, Long> readMultimap = GsonUtils.GSON.fromJson(json, multimapType);
         Assert.assertEquals(multimap, readMultimap);
+    }
+
+    public static class StreamingTableHolder {
+        @SerializedName("tbl")
+        @JsonAdapter(GsonUtils.GuavaTableTypeAdapterFactory.class)
+        public Table<Long, String, Long> tbl = HashBasedTable.create();
+    }
+
+    public static class StreamingComplexTableHolder {
+        @SerializedName("tbl")
+        @JsonAdapter(GsonUtils.GuavaTableTypeAdapterFactory.class)
+        public Table<Long, Long, Map<Long, Long>> tbl = HashBasedTable.create();
+    }
+
+    /*
+     * Same as RestoreJob.snapshotInfos/restoredVersionInfo, the streaming adapter is applied
+     * per-field via @JsonAdapter. Its output must be byte-identical to the global tree mode
+     * GuavaTableAdapter, so that journals written by old code can be replayed by new code
+     * and vice versa.
+     */
+    @Test
+    public void testStreamingTableAdapterMatchesLegacy() {
+        StreamingTableHolder holder = new StreamingTableHolder();
+        holder.tbl.put(1L, "col1", 10L);
+        holder.tbl.put(1L, "col2", 20L);
+        holder.tbl.put(2L, "col1", 30L);
+
+        String streamingJson = GsonUtils.GSON.toJson(holder);
+        // serializing the bare Table goes through the global tree mode GuavaTableAdapter
+        String legacyTableJson = GsonUtils.GSON.toJson(holder.tbl,
+                new TypeToken<Table<Long, String, Long>>() {
+                }.getType());
+        Assert.assertEquals("{\"tbl\":" + legacyTableJson + "}", streamingJson);
+
+        StreamingTableHolder read = GsonUtils.GSON.fromJson(streamingJson, StreamingTableHolder.class);
+        Assert.assertEquals(holder.tbl, read.tbl);
+    }
+
+    @Test
+    public void testStreamingTableAdapterWithComplexValue() {
+        StreamingComplexTableHolder holder = new StreamingComplexTableHolder();
+        Map<Long, Long> value = Maps.newHashMap();
+        value.put(100L, 200L);
+        holder.tbl.put(1L, 2L, value);
+
+        String streamingJson = GsonUtils.GSON.toJson(holder);
+        String legacyTableJson = GsonUtils.GSON.toJson(holder.tbl,
+                new TypeToken<Table<Long, Long, Map<Long, Long>>>() {
+                }.getType());
+        Assert.assertEquals("{\"tbl\":" + legacyTableJson + "}", streamingJson);
+
+        StreamingComplexTableHolder read = GsonUtils.GSON.fromJson(streamingJson, StreamingComplexTableHolder.class);
+        Assert.assertEquals(holder.tbl, read.tbl);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/gson/GsonSerializationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/gson/GsonSerializationTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,6 +43,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -428,5 +430,69 @@ public class GsonSerializationTest {
         MultiMapClassA readClassA = MultiMapClassA.read(in);
         Assert.assertEquals(Sets.newHashSet(new Key(MyEnum.TYPE_A, "key1"), new Key(MyEnum.TYPE_B, "key2")),
                 readClassA.map.keySet());
+    }
+
+    /*
+     * The json format of Guava Table must be byte-compatible with the legacy tree mode
+     * GuavaTableAdapter, so that old journals can be replayed and rolling upgrade is safe.
+     */
+    @Test
+    public void testGuavaTableJsonFormat() {
+        Type tableType = new TypeToken<Table<Long, String, Long>>() {
+        }.getType();
+
+        Table<Long, String, Long> table = HashBasedTable.create();
+        table.put(1L, "col1", 10L);
+        String json = GsonUtils.GSON.toJson(table, tableType);
+        Assert.assertEquals(
+                "{\"clazz\":\"HashBasedTable\",\"rowKeys\":[1],\"columnKeys\":[\"col1\"],\"cells\":[0,0,10]}",
+                json);
+
+        String legacyJson = "{\"clazz\":\"HashBasedTable\",\"rowKeys\":[1,2],\"columnKeys\":[\"col1\",\"col2\"],"
+                + "\"cells\":[0,0,10,1,1,20]}";
+        Table<Long, String, Long> readTable = GsonUtils.GSON.fromJson(legacyJson, tableType);
+        Assert.assertEquals("HashBasedTable", readTable.getClass().getSimpleName());
+        Assert.assertEquals(2, readTable.size());
+        Assert.assertEquals(Long.valueOf(10L), readTable.get(1L, "col1"));
+        Assert.assertEquals(Long.valueOf(20L), readTable.get(2L, "col2"));
+    }
+
+    /*
+     * Same as SchemaChangeJobV2.partitionIndexTabletMap, the value of Table is a Map.
+     */
+    @Test
+    public void testGuavaTableWithComplexValue() {
+        Type tableType = new TypeToken<Table<Long, Long, Map<Long, Long>>>() {
+        }.getType();
+
+        Table<Long, Long, Map<Long, Long>> table = HashBasedTable.create();
+        Map<Long, Long> value = Maps.newHashMap();
+        value.put(100L, 200L);
+        table.put(1L, 2L, value);
+
+        String json = GsonUtils.GSON.toJson(table, tableType);
+        Table<Long, Long, Map<Long, Long>> readTable = GsonUtils.GSON.fromJson(json, tableType);
+        Assert.assertEquals(1, readTable.size());
+        Assert.assertEquals(value, readTable.get(1L, 2L));
+    }
+
+    /*
+     * The json format of Guava Multimap must be byte-compatible with the legacy tree mode
+     * GuavaMultimapAdapter.
+     */
+    @Test
+    public void testGuavaMultimapJsonFormat() {
+        Type multimapType = new TypeToken<Multimap<Long, String>>() {
+        }.getType();
+
+        Multimap<Long, String> multimap = ArrayListMultimap.create();
+        multimap.put(1L, "value1");
+        multimap.put(1L, "value2");
+        String json = GsonUtils.GSON.toJson(multimap, multimapType);
+        Assert.assertEquals("{\"clazz\":\"ArrayListMultimap\",\"map\":{\"1\":[\"value1\",\"value2\"]}}", json);
+
+        Multimap<Long, String> readMultimap = GsonUtils.GSON.fromJson(json, multimapType);
+        Assert.assertEquals("ArrayListMultimap", readMultimap.getClass().getSimpleName());
+        Assert.assertEquals(Lists.newArrayList("value1", "value2"), readMultimap.get(1L));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/gson/RuntimeTypeAdapterFactoryStreamingTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/gson/RuntimeTypeAdapterFactoryStreamingTest.java
@@ -113,6 +113,15 @@ public class RuntimeTypeAdapterFactoryStreamingTest {
     }
 
     @Test
+    public void testInternalAccessHookInstalledEagerly() {
+        // withStreamingDispatch() (already called by STREAMING_GSON setup above) must
+        // have replaced the gson built-in hook with the unwrapping version, instead of
+        // deferring the installation to the first streaming read
+        Assert.assertTrue(com.google.gson.internal.JsonReaderInternalAccess.INSTANCE.getClass().getName()
+                .startsWith("org.apache.doris"));
+    }
+
+    @Test
     public void testStreamingWriteByteIdenticalWithTree() {
         Circle circle = buildCircle();
         String treeJson = TREE_GSON.toJson(circle, Shape.class);

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/gson/RuntimeTypeAdapterFactoryStreamingTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/gson/RuntimeTypeAdapterFactoryStreamingTest.java
@@ -1,0 +1,198 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.persist.gson;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Table;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/*
+ * Verifies that the streaming dispatch mode of RuntimeTypeAdapterFactory produces
+ * byte-identical json with the legacy tree mode, and that both modes can read each
+ * other's output (new-write-old-read / old-write-new-read).
+ */
+public class RuntimeTypeAdapterFactoryStreamingTest {
+
+    public abstract static class Shape {
+        @SerializedName("n")
+        public String name;
+    }
+
+    public static class Circle extends Shape {
+        @SerializedName("r")
+        public double radius;
+        @SerializedName("tags")
+        public List<String> tags = Lists.newArrayList();
+        @SerializedName("attrs")
+        public Map<String, Long> attrs = Maps.newHashMap();
+        @SerializedName("inner")
+        public Shape inner;
+        @SerializedName("tbl")
+        @JsonAdapter(GsonUtils.GuavaTableTypeAdapterFactory.class)
+        public Table<Long, Long, String> tbl = HashBasedTable.create();
+    }
+
+    public static class Rectangle extends Shape {
+        @SerializedName("w")
+        public long width;
+        @SerializedName("h")
+        public long height;
+    }
+
+    // subtype which illegally defines a field with the same name as the type field
+    public static class BadShape extends Shape {
+        @SerializedName("clazz")
+        public String clazz = "boom";
+    }
+
+    private static RuntimeTypeAdapterFactory<Shape> newFactory(boolean streaming) {
+        RuntimeTypeAdapterFactory<Shape> factory = RuntimeTypeAdapterFactory.of(Shape.class, "clazz");
+        if (streaming) {
+            factory.withStreamingDispatch();
+        }
+        return factory.registerSubtype(Circle.class, Circle.class.getSimpleName())
+                .registerSubtype(Rectangle.class, Rectangle.class.getSimpleName())
+                .registerSubtype(BadShape.class, BadShape.class.getSimpleName());
+    }
+
+    private static Gson newGson(boolean streaming) {
+        // mirror the relevant GSON_BUILDER settings
+        return new GsonBuilder()
+                .serializeSpecialFloatingPointValues()
+                .enableComplexMapKeySerialization()
+                .registerTypeAdapterFactory(newFactory(streaming))
+                .create();
+    }
+
+    private static final Gson TREE_GSON = newGson(false);
+    private static final Gson STREAMING_GSON = newGson(true);
+
+    private static Circle buildCircle() {
+        Circle circle = new Circle();
+        circle.name = "special <html> &chars\" 中文";
+        circle.radius = 3.25;
+        circle.tags.add("a");
+        circle.tags.add(null);
+        circle.tags.add("b");
+        circle.attrs.put("x", 1L);
+        Rectangle inner = new Rectangle();
+        inner.name = null; // omitted by default serializeNulls=false
+        inner.width = 10;
+        inner.height = 20;
+        circle.inner = inner;
+        circle.tbl.put(1L, 2L, "v12");
+        circle.tbl.put(1L, 3L, "v13");
+        circle.tbl.put(4L, 2L, "v42");
+        return circle;
+    }
+
+    @Test
+    public void testStreamingWriteByteIdenticalWithTree() {
+        Circle circle = buildCircle();
+        String treeJson = TREE_GSON.toJson(circle, Shape.class);
+        String streamingJson = STREAMING_GSON.toJson(circle, Shape.class);
+        Assert.assertEquals(treeJson, streamingJson);
+        Assert.assertTrue(streamingJson.startsWith("{\"clazz\":\"Circle\","));
+
+        Rectangle rectangle = new Rectangle();
+        rectangle.width = 7;
+        Assert.assertEquals(TREE_GSON.toJson(rectangle, Shape.class),
+                STREAMING_GSON.toJson(rectangle, Shape.class));
+    }
+
+    @Test
+    public void testCrossModeRoundTrip() {
+        Circle circle = buildCircle();
+        String treeJson = TREE_GSON.toJson(circle, Shape.class);
+        String streamingJson = STREAMING_GSON.toJson(circle, Shape.class);
+
+        // new-write-old-read and old-write-new-read
+        Circle fromTreeByStreaming = (Circle) STREAMING_GSON.fromJson(treeJson, Shape.class);
+        Circle fromStreamingByTree = (Circle) TREE_GSON.fromJson(streamingJson, Shape.class);
+        Circle fromStreamingByStreaming = (Circle) STREAMING_GSON.fromJson(streamingJson, Shape.class);
+
+        for (Circle restored : Lists.newArrayList(fromTreeByStreaming, fromStreamingByTree,
+                fromStreamingByStreaming)) {
+            Assert.assertEquals(circle.name, restored.name);
+            Assert.assertEquals(circle.radius, restored.radius, 0);
+            Assert.assertEquals(circle.tags, restored.tags);
+            Assert.assertEquals(circle.attrs, restored.attrs);
+            Assert.assertEquals(((Rectangle) circle.inner).width, ((Rectangle) restored.inner).width);
+            Assert.assertEquals(circle.tbl, restored.tbl);
+        }
+    }
+
+    @Test
+    public void testStreamingReadRequiresTypeFieldFirst() {
+        // legacy tree read tolerates the type field at any position, streaming read does not;
+        // all Doris-generated data always has it first, so fail fast on mismatch
+        String typeFieldSecond = "{\"w\":7,\"clazz\":\"Rectangle\",\"h\":8}";
+        Rectangle byTree = (Rectangle) TREE_GSON.fromJson(typeFieldSecond, Shape.class);
+        Assert.assertEquals(7, byTree.width);
+        try {
+            STREAMING_GSON.fromJson(typeFieldSecond, Shape.class);
+            Assert.fail("expect JsonParseException");
+        } catch (JsonParseException e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("the first field is 'w'"));
+        }
+    }
+
+    @Test
+    public void testStreamingWriteRejectsConflictTypeField() {
+        try {
+            STREAMING_GSON.toJson(new BadShape(), Shape.class);
+            Assert.fail("expect JsonParseException");
+        } catch (JsonParseException e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("already defines a field named clazz"));
+        }
+        // same behavior as the tree mode
+        try {
+            TREE_GSON.toJson(new BadShape(), Shape.class);
+            Assert.fail("expect JsonParseException");
+        } catch (JsonParseException e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("already defines a field named clazz"));
+        }
+    }
+
+    @Test
+    public void testStreamingReadUnknownSubtype() {
+        try {
+            STREAMING_GSON.fromJson("{\"clazz\":\"Triangle\",\"n\":\"x\"}", Shape.class);
+            Assert.fail("expect JsonParseException");
+        } catch (JsonParseException e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("subtype named Triangle"));
+        }
+    }
+
+    @Test
+    public void testNullValue() {
+        Assert.assertEquals("null", STREAMING_GSON.toJson(null, Shape.class));
+        Assert.assertNull(STREAMING_GSON.fromJson("null", Shape.class));
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

When a backup/restore job involves a large number of tablets (e.g. 50k+ tablets), persisting the job to the edit log causes severe FE heap pressure (an 81MB `OP_RESTORE_JOB` journal entry transiently allocates dozens of times its size), which can lead to FE Full GC / OOM. There are two layers of tree-mode (DOM) materialization in the Gson path:

1. **Field level**: the Gson adapters for Guava `Table` work in tree mode (`JsonSerializer`/`JsonDeserializer`): they materialize the whole `JsonElement` DOM of the huge `snapshotInfos` / `restoredVersionInfo` fields.
2. **Job level**: `RuntimeTypeAdapterFactory` (polymorphic dispatch on `clazz`) converts the **entire job** to a `JsonElement` DOM on write (`toJsonTree` + clone to put `clazz` first) and parses the full stream into a DOM on read (`Streams.parse`), regardless of any field-level streaming.

This PR fixes both layers:

**Commit 1-3 (field level)**: a streaming `TypeAdapterFactory` (`GuavaTableTypeAdapterFactory`) writes directly to `JsonWriter` / reads directly from `JsonReader` without building the DOM, applied **per-field via `@JsonAdapter`, only on `RestoreJob.snapshotInfos` and `RestoreJob.restoredVersionInfo`**. The global tree-mode `GuavaTableAdapter`/`GuavaMultimapAdapter` registrations are untouched, so all other persisted metadata keeps the battle-tested legacy path.

**Commit 4 (job level)**: an opt-in `withStreamingDispatch()` mode for `RuntimeTypeAdapterFactory`, enabled **only for `jobBackupTypeAdapterFactory` (BackupJob / RestoreJob / CloudRestoreJob)**:

- Write: a pass-through `TypeFieldInjectingJsonWriter` injects `"clazz": label` right after the first `beginObject()`, producing byte-identical output to tree mode, and fails fast on a conflicting top-level field name.
- Read: requires `clazz` to be the first field (always true for Doris-generated journals/images since tree mode always emits it first); after consuming it, the remaining stream is handed to the subtype delegate via a pass-through `EnteredObjectJsonReader`. Gson's `MapTypeAdapterFactory` promotes map keys through the global `JsonReaderInternalAccess` hook which manipulates `JsonReader` internals directly, so the hook is replaced once with an unwrapping version (behavior for all other readers unchanged).

Allocation probe results (`ThreadMXBean.getThreadAllocatedBytes`, 100k-tablet RestoreJob, ratio = transient allocation / serialized size):

| path | before | field-level only | field-level + streaming dispatch |
|---|---|---|---|
| write (`toJson`) | 55.9x | 41.6x | **15.9x** (steady state) |
| read (replay via `AbstractJob`) | 112.5x | 30.2x | **10.3x** |

Real-cluster verification (51200 tablets, 8GB heap FE, this exact branch build):

- backup + restore full pass, restore FINISHED in 403s, 0 `JsonParseException`
- `editlog_max_interval_jump` = 81.20MB, byte-identical to the previous build (format unchanged)
- old-write-new-read: FE restarted on pre-existing metadata written by the previous build, replay clean
- new-write-new-read: FE restarted after the run, replayed the 81MB streaming-written `OP_RESTORE_JOB` entry, replay clean, data queryable

Compatibility:

- The json format is byte-identical between streaming and tree mode at both layers, guarded by exact-format unit tests and cross-mode round-trip tests (new-write-old-read / old-write-new-read). Old journals can be replayed by new code and vice versa; rolling upgrade and rollback are safe.
- Streaming readers fail fast on field-order mismatch instead of silently misreading.

### Release note

None

### Check List (For Author)

- Test: Regression test / Unit Test / Manual test
 - Unit Test: GsonSerializationTest (exact json format pinning, streaming-vs-legacy byte comparison), RuntimeTypeAdapterFactoryStreamingTest (byte-identical output, cross-mode round-trip both directions, clazz-first enforcement, conflicting field fail-fast, unknown subtype error), RestoreJobTest, BackupJobTest, BackupHandlerTest, SchemaChangeJobV2Test, GsonDerivedClassSerializationTest — full `org.apache.doris.persist.gson.*` + `org.apache.doris.backup.*` regression: 60 tests, 0 failures
 - Manual test: real-cluster backup+restore of 51200 tablets with double FE restart/replay verification (old-write-new-read and new-write-new-read), built from this branch
- Behavior changed: No (json format unchanged, byte-identical)
- Does this need documentation: No
