### PR TITLE
[fix](statistics) Add analyze OOM hint for statistics task

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2551,7 +2551,7 @@ public class Config extends ConfigBase {
     @ConfField
     public static int statistics_sql_parallel_exec_instance_num = 1;
 
-    @ConfField
+    @ConfField(mutable = true)
     public static long statistics_sql_mem_limit_in_bytes = 2L * 1024 * 1024 * 1024;
 
     @ConfField(mutable = true, masterOnly = true, description = {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskWrapper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskWrapper.java
@@ -31,6 +31,9 @@ import java.util.concurrent.FutureTask;
 public class AnalysisTaskWrapper extends FutureTask<Void> {
 
     private static final Logger LOG = LogManager.getLogger(AnalysisTaskWrapper.class);
+    private static final String STATISTICS_ANALYZE_OOM_HINT = "For statistics analyze, you can increase "
+            + "`statistics_sql_mem_limit_in_bytes`, decrease `huge_table_default_sample_rows`, "
+            + "or use `statistics_max_string_column_length` to skip large string columns.";
 
     private final BaseAnalysisTask task;
 
@@ -74,7 +77,7 @@ public class AnalysisTaskWrapper extends FutureTask<Void> {
             if (!task.killed) {
                 if (except != null) {
                     LOG.warn("Analyze {} failed.", task.toString(), except);
-                    task.job.taskFailed(task, Util.getRootCauseMessage(except));
+                    task.job.taskFailed(task, appendStatisticsAnalyzeOOMHint(Util.getRootCauseMessage(except)));
                 }
             }
         }
@@ -85,10 +88,19 @@ public class AnalysisTaskWrapper extends FutureTask<Void> {
             LOG.warn("{} cancelled, cost time:{}", task.toString(), System.currentTimeMillis() - startTime);
             task.cancel();
         } catch (Exception e) {
-            LOG.warn(String.format("Cancel job failed job info : %s", msg));
+            LOG.warn(String.format("Cancel job failed job info : %s",
+                    appendStatisticsAnalyzeOOMHint(Util.getRootCauseMessage(e))));
         }
         // Interrupt thread when it's writing metadata would cause FE crush.
         return super.cancel(false);
+    }
+
+    private String appendStatisticsAnalyzeOOMHint(String msg) {
+        if (msg == null || !msg.contains("MEM_LIMIT_EXCEEDED")
+                || msg.contains("statistics_sql_mem_limit_in_bytes")) {
+            return msg;
+        }
+        return msg + "\n" + STATISTICS_ANALYZE_OOM_HINT;
     }
 
     public long getStartTime() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskWrapper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskWrapper.java
@@ -88,8 +88,8 @@ public class AnalysisTaskWrapper extends FutureTask<Void> {
             LOG.warn("{} cancelled, cost time:{}", task.toString(), System.currentTimeMillis() - startTime);
             task.cancel();
         } catch (Exception e) {
-            LOG.warn(String.format("Cancel job failed job info : %s",
-                    appendStatisticsAnalyzeOOMHint(Util.getRootCauseMessage(e))));
+            LOG.warn("Cancel job failed job info: {}, cause: {}",
+                    msg, appendStatisticsAnalyzeOOMHint(Util.getRootCauseMessage(e)), e);
         }
         // Interrupt thread when it's writing metadata would cause FE crush.
         return super.cancel(false);

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskWrapperTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskWrapperTest.java
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.statistics.AnalysisInfo.ScheduleType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class AnalysisTaskWrapperTest {
+
+    @Test
+    public void testOOMErrorMessageReplacement() throws Exception {
+        AnalysisInfo analysisInfo = new AnalysisInfoBuilder().setJobId(1).setTaskId(2)
+                .setScheduleType(ScheduleType.ONCE).build();
+        AnalysisJob mockJob = Mockito.mock(AnalysisJob.class);
+
+        BaseAnalysisTask task = new BaseAnalysisTask() {
+            @Override
+            public void execute() throws Exception {
+                doExecute();
+            }
+
+            @Override
+            public void doExecute() throws Exception {
+                throw new Exception("(172.16.0.90)[MEM_LIMIT_EXCEEDED]PreCatch error code:11, "
+                        + "[E11] Allocator mem tracker check failed... can `set exec_mem_limit` to change limit, "
+                        + "details see be.INFO.");
+            }
+
+            @Override
+            protected void doSample() {
+            }
+
+            @Override
+            protected void deleteNotExistPartitionStats(AnalysisInfo jobInfo) throws DdlException {
+            }
+
+            @Override
+            public String toString() {
+                return "test-analysis-task";
+            }
+        };
+        task.info = analysisInfo;
+        task.job = mockJob;
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnv.when(Env::isCheckpointThread).thenReturn(true);
+            AnalysisTaskExecutor executor = new AnalysisTaskExecutor(1);
+            AnalysisTaskWrapper wrapper = new AnalysisTaskWrapper(executor, task);
+
+            wrapper.run();
+        }
+
+        ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(mockJob).taskFailed(Mockito.eq(task), msgCaptor.capture());
+        String errorMsg = msgCaptor.getValue();
+        Mockito.verifyNoMoreInteractions(mockJob);
+        Assertions.assertTrue(errorMsg.contains("can `set exec_mem_limit` to change limit"));
+        Assertions.assertTrue(
+                errorMsg.contains("For statistics analyze, you can increase `statistics_sql_mem_limit_in_bytes`, "
+                        + "decrease `huge_table_default_sample_rows`, "
+                        + "or use `statistics_max_string_column_length` to skip large string columns."));
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: apache/doris#63172

Problem Summary: Backport apache/doris#63172 to HYDCP branch-3.1. Statistics analyze tasks may surface BE MEM_LIMIT_EXCEEDED errors that suggest changing exec_mem_limit, which is misleading for internal statistics SQL. This change appends a statistics-specific hint and makes statistics_sql_mem_limit_in_bytes mutable.

### Release note

Improve the error hint for statistics analyze OOM failures.

### Check List (For Author)

- Test: Unit Test
    - ./run-fe-ut.sh --run org.apache.doris.statistics.AnalysisTaskWrapperTest
- Behavior changed: Yes. Statistics analyze MEM_LIMIT_EXCEEDED errors include an additional statistics-specific tuning hint.
- Does this need documentation: No