### PR TITLE
[fix](catalog) Handle incomplete dynamic partition properties

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1941,6 +1941,12 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
         // After that, some properties of fullSchema and nameToColumn may be not same as properties of base columns.
         // So, here we need to rebuild the fullSchema to ensure the correctness of the properties.
         rebuildFullSchema();
+
+        if (tableProperty != null && tableProperty.hasInvalidDynamicPartition()) {
+            LOG.warn("Table [{}-{}] has incomplete dynamic partition properties {}, "
+                    + "treat it as a non-dynamic-partition table.",
+                    name, id, tableProperty.getOriginDynamicPartitionProperty());
+        }
     }
 
     public OlapTable selectiveCopy(Collection<String> reservedPartitions, IndexExtState extState, boolean isForBackup) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -66,6 +66,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
     // the follower variables are built from "properties"
     private DynamicPartitionProperty dynamicPartitionProperty =
             EnvFactory.getInstance().createDynamicPartitionProperty(Maps.newHashMap());
+    // True when "properties" carries dynamic_partition.* entries that are incomplete
+    // (missing required keys) and were ignored when building dynamicPartitionProperty.
+    // Derived from "properties", not persisted.
+    private boolean invalidDynamicPartition = false;
     private ReplicaAllocation replicaAlloc = ReplicaAllocation.DEFAULT_ALLOCATION;
     private boolean isInMemory = false;
     private short minLoadReplicaNum = -1;
@@ -214,13 +218,37 @@ public class TableProperty implements Writable, GsonPostProcessable {
             if (entry.getKey().startsWith(DynamicPartitionProperty.DYNAMIC_PARTITION_PROPERTY_PREFIX)) {
                 if (!DynamicPartitionProperty.DYNAMIC_PARTITION_PROPERTIES.contains(entry.getKey())) {
                     LOG.warn("Ignore invalid dynamic property key: {}: value: {}", entry.getKey(), entry.getValue());
+                    continue;
                 }
                 dynamicPartitionProperties.put(entry.getKey(), entry.getValue());
             }
         }
 
+        if (!dynamicPartitionProperties.isEmpty()
+                && !hasRequiredDynamicPartitionProperties(dynamicPartitionProperties)) {
+            LOG.warn("Ignore incomplete dynamic partition properties: {}", dynamicPartitionProperties);
+            dynamicPartitionProperty = EnvFactory.getInstance().createDynamicPartitionProperty(Maps.newHashMap());
+            invalidDynamicPartition = true;
+            return this;
+        }
+        invalidDynamicPartition = false;
         dynamicPartitionProperty = EnvFactory.getInstance().createDynamicPartitionProperty(dynamicPartitionProperties);
         return this;
+    }
+
+    // Required keys of a usable dynamic partition config. END/BUCKETS have no null-safe default
+    // in DynamicPartitionProperty's constructor (Integer.parseInt), so a raw map carrying only
+    // optional keys (e.g. a leftover storage_medium/storage_policy from a failed ALTER) must be
+    // rejected here to avoid parseInt(null) during backup/selectiveCopy/image replay.
+    private boolean hasRequiredDynamicPartitionProperties(Map<String, String> dynamicPartitionProperties) {
+        return dynamicPartitionProperties.containsKey(DynamicPartitionProperty.TIME_UNIT)
+                && dynamicPartitionProperties.containsKey(DynamicPartitionProperty.END)
+                && dynamicPartitionProperties.containsKey(DynamicPartitionProperty.PREFIX)
+                && dynamicPartitionProperties.containsKey(DynamicPartitionProperty.BUCKETS);
+    }
+
+    public boolean hasInvalidDynamicPartition() {
+        return invalidDynamicPartition;
     }
 
     public TableProperty buildInMemory() {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
@@ -464,6 +464,8 @@ public class DynamicPartitionUtil {
         String createHistoryPartition = properties.get(DynamicPartitionProperty.CREATE_HISTORY_PARTITION);
         String historyPartitionNum = properties.get(DynamicPartitionProperty.HISTORY_PARTITION_NUM);
         String reservedHistoryPeriods = properties.get(DynamicPartitionProperty.RESERVED_HISTORY_PERIODS);
+        String storagePolicy = properties.get(DynamicPartitionProperty.STORAGE_POLICY);
+        String storageMedium = properties.get(DynamicPartitionProperty.STORAGE_MEDIUM);
 
         if (!(Strings.isNullOrEmpty(enable)
                 && Strings.isNullOrEmpty(timeUnit)
@@ -474,7 +476,9 @@ public class DynamicPartitionUtil {
                 && Strings.isNullOrEmpty(buckets)
                 && Strings.isNullOrEmpty(createHistoryPartition)
                 && Strings.isNullOrEmpty(historyPartitionNum)
-                && Strings.isNullOrEmpty(reservedHistoryPeriods))) {
+                && Strings.isNullOrEmpty(reservedHistoryPeriods)
+                && Strings.isNullOrEmpty(storagePolicy)
+                && Strings.isNullOrEmpty(storageMedium))) {
             if (Strings.isNullOrEmpty(enable)) {
                 properties.put(DynamicPartitionProperty.ENABLE, "true");
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -22,10 +22,13 @@ import org.apache.doris.analysis.TableName;
 import org.apache.doris.analysis.TableRef;
 import org.apache.doris.backup.BackupJob.BackupJobState;
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.DynamicPartitionProperty;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FsBroker;
+import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.TableProperty;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
@@ -380,6 +383,32 @@ public class BackupJobTest {
         job.run();
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(BackupJobState.FINISHED, job.getState());
+    }
+
+    @Test
+    public void testBackupCopyTableWithDirtyDynamicPartitionStorageMedium() {
+        Map<String, String> dirtyProperties = Maps.newHashMap();
+        dirtyProperties.put(DynamicPartitionProperty.STORAGE_MEDIUM, "hdd");
+        table2.setTableProperty(new TableProperty(dirtyProperties));
+
+        Assert.assertFalse(table2.dynamicPartitionExists());
+        OlapTable copied = table2.selectiveCopy(null, IndexExtState.VISIBLE, true);
+        Assert.assertNotNull(copied);
+        Assert.assertFalse(copied.dynamicPartitionExists());
+        Assert.assertTrue(copied.getTableProperty().hasInvalidDynamicPartition());
+    }
+
+    @Test
+    public void testBackupCopyTableWithDirtyDynamicPartitionStoragePolicy() {
+        Map<String, String> dirtyProperties = Maps.newHashMap();
+        dirtyProperties.put(DynamicPartitionProperty.STORAGE_POLICY, "test_policy");
+        table2.setTableProperty(new TableProperty(dirtyProperties));
+
+        Assert.assertFalse(table2.dynamicPartitionExists());
+        OlapTable copied = table2.selectiveCopy(null, IndexExtState.VISIBLE, true);
+        Assert.assertNotNull(copied);
+        Assert.assertFalse(copied.dynamicPartitionExists());
+        Assert.assertTrue(copied.getTableProperty().hasInvalidDynamicPartition());
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -1676,6 +1676,102 @@ public class DynamicPartitionTableTest {
     }
 
     @Test
+    public void testRejectDynamicPartitionStorageMediumOnNonDynamicTable() throws Exception {
+        String createOlapTblStmt = "CREATE TABLE test.`non_dynamic_storage_medium` (\n"
+                + "  `k1` date NULL COMMENT \"\",\n"
+                + "  `v1` int NULL COMMENT \"\"\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(`k1`)\n"
+                + "PARTITION BY RANGE(`k1`)\n"
+                + "(\n"
+                + "PARTITION p1 VALUES [('2026-05-26'), ('2026-05-27')),\n"
+                + "PARTITION p2 VALUES [('2026-05-27'), ('2026-05-28'))\n"
+                + ")\n"
+                + "DISTRIBUTED BY HASH(`k1`) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + "\"replication_num\" = \"1\"\n"
+                + ");";
+        createTable(createOlapTblStmt);
+
+        String alterStmt = "ALTER TABLE test.`non_dynamic_storage_medium` "
+                + "SET (\"dynamic_partition.storage_medium\" = \"hdd\")";
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "is not a dynamic partition table",
+                () -> alterTable(alterStmt));
+
+        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("non_dynamic_storage_medium");
+        Assert.assertFalse(table.dynamicPartitionExists());
+        Assert.assertFalse(table.getTableProperty().getProperties()
+                .containsKey(DynamicPartitionProperty.STORAGE_MEDIUM));
+        Assert.assertNotNull(table.selectiveCopy(null, IndexExtState.VISIBLE, true));
+    }
+
+    @Test
+    public void testRejectDynamicPartitionStoragePolicyOnNonDynamicTable() throws Exception {
+        String createOlapTblStmt = "CREATE TABLE test.`non_dynamic_storage_policy` (\n"
+                + "  `k1` date NULL COMMENT \"\",\n"
+                + "  `v1` int NULL COMMENT \"\"\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(`k1`)\n"
+                + "PARTITION BY RANGE(`k1`)\n"
+                + "(\n"
+                + "PARTITION p1 VALUES [('2026-05-26'), ('2026-05-27')),\n"
+                + "PARTITION p2 VALUES [('2026-05-27'), ('2026-05-28'))\n"
+                + ")\n"
+                + "DISTRIBUTED BY HASH(`k1`) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + "\"replication_num\" = \"1\"\n"
+                + ");";
+        createTable(createOlapTblStmt);
+
+        String alterStmt = "ALTER TABLE test.`non_dynamic_storage_policy` "
+                + "SET (\"dynamic_partition.storage_policy\" = \"test_policy\")";
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "is not a dynamic partition table",
+                () -> alterTable(alterStmt));
+
+        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("non_dynamic_storage_policy");
+        Assert.assertFalse(table.dynamicPartitionExists());
+        Assert.assertFalse(table.getTableProperty().getProperties()
+                .containsKey(DynamicPartitionProperty.STORAGE_POLICY));
+        Assert.assertNotNull(table.selectiveCopy(null, IndexExtState.VISIBLE, true));
+    }
+
+    @Test
+    public void testAlterDynamicPartitionStorageMediumOnDynamicTable() throws Exception {
+        String createOlapTblStmt = "CREATE TABLE test.`dynamic_storage_medium` (\n"
+                + "  `k1` date NULL COMMENT \"\",\n"
+                + "  `v1` int NULL COMMENT \"\"\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(`k1`)\n"
+                + "PARTITION BY RANGE(`k1`)()\n"
+                + "DISTRIBUTED BY HASH(`k1`) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + "\"replication_num\" = \"1\",\n"
+                + "\"dynamic_partition.enable\" = \"true\",\n"
+                + "\"dynamic_partition.time_unit\" = \"DAY\",\n"
+                + "\"dynamic_partition.start\" = \"-1\",\n"
+                + "\"dynamic_partition.end\" = \"3\",\n"
+                + "\"dynamic_partition.prefix\" = \"p\",\n"
+                + "\"dynamic_partition.buckets\" = \"1\"\n"
+                + ");";
+        createTable(createOlapTblStmt);
+
+        String alterStmt = "ALTER TABLE test.`dynamic_storage_medium` "
+                + "SET (\"dynamic_partition.storage_medium\" = \"hdd\")";
+        ExceptionChecker.expectThrowsNoException(() -> alterTable(alterStmt));
+
+        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("dynamic_storage_medium");
+        Assert.assertTrue(table.dynamicPartitionExists());
+        Assert.assertEquals("hdd", table.getTableProperty().getDynamicPartitionProperty().getStorageMedium());
+        Assert.assertEquals(3, table.getTableProperty().getDynamicPartitionProperty().getEnd());
+        Assert.assertEquals(1, table.getTableProperty().getDynamicPartitionProperty().getBuckets());
+    }
+
+    @Test
     public void testHourUnitWithDateType() throws AnalysisException {
         String createOlapTblStmt = "CREATE TABLE if not exists test.hour_with_date1 (\n"
                 + "  `days` DATEV2 NOT NULL,\n"

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/TablePropertyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/TablePropertyTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.doris.catalog;
 
-
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.meta.MetaContext;
 
+import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Map;
 
 public class TablePropertyTest {
 
@@ -72,5 +73,86 @@ public class TablePropertyTest {
 
         in.close();
         Files.delete(path);
+    }
+
+    // A non-whitelisted dynamic_partition.* key is ignored (skipped via continue), so it is not
+    // collected at all and the table is neither built as dynamic nor flagged as incomplete.
+    @Test
+    public void testIgnoreInvalidDynamicPartitionPropertyKey() {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(DynamicPartitionProperty.DYNAMIC_PARTITION_PROPERTY_PREFIX + "not_a_real_key", "1");
+        TableProperty tableProperty = new TableProperty(properties).buildDynamicProperty();
+        Assert.assertFalse(tableProperty.getDynamicPartitionProperty().isExist());
+        Assert.assertFalse(tableProperty.hasInvalidDynamicPartition());
+    }
+
+    // Only storage_medium (a leftover from a failed ALTER on a non-dynamic table): incomplete,
+    // must be downgraded to a non-dynamic-partition table instead of crashing on parseInt(null).
+    @Test
+    public void testIncompleteStorageMediumIsDowngraded() {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(DynamicPartitionProperty.STORAGE_MEDIUM, "hdd");
+        TableProperty tableProperty = new TableProperty(properties).buildDynamicProperty();
+        Assert.assertFalse(tableProperty.getDynamicPartitionProperty().isExist());
+        Assert.assertTrue(tableProperty.hasInvalidDynamicPartition());
+    }
+
+    // Symmetric to storage_medium: a leftover storage_policy alone is also incomplete.
+    @Test
+    public void testIncompleteStoragePolicyIsDowngraded() {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(DynamicPartitionProperty.STORAGE_POLICY, "test_policy");
+        TableProperty tableProperty = new TableProperty(properties).buildDynamicProperty();
+        Assert.assertFalse(tableProperty.getDynamicPartitionProperty().isExist());
+        Assert.assertTrue(tableProperty.hasInvalidDynamicPartition());
+    }
+
+    // time_unit present but end missing: still incomplete (covers the END required-key branch).
+    @Test
+    public void testIncompleteMissingEndIsDowngraded() {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(DynamicPartitionProperty.TIME_UNIT, "DAY");
+        TableProperty tableProperty = new TableProperty(properties).buildDynamicProperty();
+        Assert.assertFalse(tableProperty.getDynamicPartitionProperty().isExist());
+        Assert.assertTrue(tableProperty.hasInvalidDynamicPartition());
+    }
+
+    // time_unit + end present but prefix missing (covers the PREFIX required-key branch).
+    @Test
+    public void testIncompleteMissingPrefixIsDowngraded() {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(DynamicPartitionProperty.TIME_UNIT, "DAY");
+        properties.put(DynamicPartitionProperty.END, "3");
+        TableProperty tableProperty = new TableProperty(properties).buildDynamicProperty();
+        Assert.assertFalse(tableProperty.getDynamicPartitionProperty().isExist());
+        Assert.assertTrue(tableProperty.hasInvalidDynamicPartition());
+    }
+
+    // time_unit + end + prefix present but buckets missing (covers the BUCKETS required-key branch).
+    @Test
+    public void testIncompleteMissingBucketsIsDowngraded() {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(DynamicPartitionProperty.TIME_UNIT, "DAY");
+        properties.put(DynamicPartitionProperty.END, "3");
+        properties.put(DynamicPartitionProperty.PREFIX, "p");
+        TableProperty tableProperty = new TableProperty(properties).buildDynamicProperty();
+        Assert.assertFalse(tableProperty.getDynamicPartitionProperty().isExist());
+        Assert.assertTrue(tableProperty.hasInvalidDynamicPartition());
+    }
+
+    // All required keys present: a real DynamicPartitionProperty is built, not downgraded.
+    @Test
+    public void testCompleteDynamicPartitionIsBuilt() {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(DynamicPartitionProperty.ENABLE, "true");
+        properties.put(DynamicPartitionProperty.TIME_UNIT, "DAY");
+        properties.put(DynamicPartitionProperty.END, "3");
+        properties.put(DynamicPartitionProperty.PREFIX, "p");
+        properties.put(DynamicPartitionProperty.BUCKETS, "1");
+        TableProperty tableProperty = new TableProperty(properties).buildDynamicProperty();
+        Assert.assertTrue(tableProperty.getDynamicPartitionProperty().isExist());
+        Assert.assertFalse(tableProperty.hasInvalidDynamicPartition());
+        Assert.assertEquals(3, tableProperty.getDynamicPartitionProperty().getEnd());
+        Assert.assertEquals(1, tableProperty.getDynamicPartitionProperty().getBuckets());
     }
 }


### PR DESCRIPTION
## Summary
- Backport PR apache/doris#63831 behavior to branch-3.1 for incomplete dynamic partition properties.
- Ignore incomplete dynamic partition metadata during table property rebuild and log table identity for diagnosis.
- Reject `dynamic_partition.storage_medium` and `dynamic_partition.storage_policy` on non-dynamic tables consistently with upstream PR behavior.

## Test plan
- `./run-fe-ut.sh --run org.apache.doris.catalog.DynamicPartitionTableTest#testRejectDynamicPartitionStorageMediumOnNonDynamicTable+testRejectDynamicPartitionStoragePolicyOnNonDynamicTable`
- `./run-fe-ut.sh --run org.apache.doris.catalog.TablePropertyTest,org.apache.doris.backup.BackupJobTest#testBackupCopyTableWithDirtyDynamicPartitionStorageMedium+testBackupCopyTableWithDirtyDynamicPartitionStoragePolicy,org.apache.doris.catalog.DynamicPartitionTableTest#testRejectDynamicPartitionStorageMediumOnNonDynamicTable+testRejectDynamicPartitionStoragePolicyOnNonDynamicTable+testAlterDynamicPartitionStorageMediumOnDynamicTable`
- `./build.sh --fe` was started, but it was manually backgrounded before completion, so no pass result is claimed.


Made with [Cursor](https://cursor.com)