### PR TITLE
[fix](fe) Reduce stream load redirect drain idle timeout default to 2s

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3318,7 +3318,7 @@ public class Config extends ConfigBase {
             "The maximum idle wait time in milliseconds after FE detects no readable request body bytes "
                     + "during Stream Load redirect drain. 0 disables the extra idle wait, while a positive value "
                     + "keeps a bounded grace window for slow clients or delayed request body chunks."})
-    public static int stream_load_redirect_bounded_drain_max_idle_time_ms = 10000;
+    public static int stream_load_redirect_bounded_drain_max_idle_time_ms = 2000;
 
     @ConfField(mutable = true, description = {
             "存算分离模式下是否启用group commit的streamload BE转发功能。"


### PR DESCRIPTION
## Summary
Reduce the default value of stream_load_redirect_bounded_drain_max_idle_time_ms from 10000 to 2000.

## Motivation
2GB stream load redirect tests show that 10s is too conservative and keeps clients uploading useless body data for too long after FE already returns 307.

## Test
Attempted FE UT with run-fe-ut.sh for LoadActionTest and StreamLoadRedirectDrainUtilTest, but the local environment is missing thirdparty/installed/bin/protoc, so the test run is blocked before executing the target cases.