### PR TITLE
[fix](fe) 修复 snapshot RPC 返回 master 地址

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -3075,6 +3075,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         result.setStatus(status);
 
         if (status.getStatusCode() != TStatusCode.OK) {
+            setMasterAddressIfValid(result::setMasterAddress);
             return result;
         }
 
@@ -3189,6 +3190,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         result.setStatus(status);
 
         if (status.getStatusCode() != TStatusCode.OK) {
+            setMasterAddressIfValid(result::setMasterAddress);
             return result;
         }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
@@ -49,12 +49,16 @@ import org.apache.doris.thrift.TGetDbsParams;
 import org.apache.doris.thrift.TGetDbsResult;
 import org.apache.doris.thrift.TGetMasterTokenRequest;
 import org.apache.doris.thrift.TGetMasterTokenResult;
+import org.apache.doris.thrift.TGetSnapshotRequest;
+import org.apache.doris.thrift.TGetSnapshotResult;
 import org.apache.doris.thrift.TLockBinlogRequest;
 import org.apache.doris.thrift.TLockBinlogResult;
 import org.apache.doris.thrift.TMetadataTableRequestParams;
 import org.apache.doris.thrift.TMetadataType;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TNullableStringLiteral;
+import org.apache.doris.thrift.TRestoreSnapshotRequest;
+import org.apache.doris.thrift.TRestoreSnapshotResult;
 import org.apache.doris.thrift.TRollbackTxnRequest;
 import org.apache.doris.thrift.TRollbackTxnResult;
 import org.apache.doris.thrift.TSchemaTableName;
@@ -178,6 +182,14 @@ public class FrontendServiceImplTest {
             TLockBinlogResult lockBinlogResult = impl.lockBinlog(new TLockBinlogRequest());
             Assert.assertEquals(TStatusCode.NOT_MASTER, lockBinlogResult.getStatus().getStatusCode());
             assertNotMasterWithAddress(lockBinlogResult.getMasterAddress());
+
+            TGetSnapshotResult getSnapshotResult = impl.getSnapshot(new TGetSnapshotRequest());
+            Assert.assertEquals(TStatusCode.NOT_MASTER, getSnapshotResult.getStatus().getStatusCode());
+            assertNotMasterWithAddress(getSnapshotResult.getMasterAddress());
+
+            TRestoreSnapshotResult restoreSnapshotResult = impl.restoreSnapshot(new TRestoreSnapshotRequest());
+            Assert.assertEquals(TStatusCode.NOT_MASTER, restoreSnapshotResult.getStatus().getStatusCode());
+            assertNotMasterWithAddress(restoreSnapshotResult.getMasterAddress());
         }
     }
 


### PR DESCRIPTION
## Summary
- 补齐之前 CCR `NOT_MASTER` master_address 修复 PR 遗漏的两个 full sync snapshot RPC：`getSnapshot` 和 `restoreSnapshot`。
- 当 follower FE 返回 `NOT_MASTER` 时，为这两个 RPC 设置 `master_address`，使 CCR syncer 可以重定向到 master FE。
- 扩展已有 FE 单测 `testNotMasterCcrApisReturnValidMasterAddress`，覆盖 snapshot RPC。

## 背景
之前的 PR 已覆盖 CCR 常用事务和 binlog RPC，例如 `beginTxn`、`commitTxn`、`rollbackTxn`、`getMasterToken`、`getBinlog`、`getBinlogLag`、`lockBinlog`。

真实 CCR full sync 验证发现还会调用 `restoreSnapshot`，且 `getSnapshot` 也存在同类行为：它们在 follower FE 上返回 `NOT_MASTER` 时没有带 `master_address`，导致 syncer 无法重定向并报：

```text
[fe] not master compatible
```

本 PR 是对之前 PR 覆盖范围的补充修复。

## Test plan
- `mvn checkstyle:check -pl fe-core`
- `mvn test -pl fe-core -am -Dtest=FrontendServiceImplTest#testGetSnapshotReturnsMasterAddressWhenNotMaster+testRestoreSnapshotReturnsMasterAddressWhenNotMaster -DskipITs -Dskip.doc=true`
- `./build.sh --fe`
- 真实 CCR 表级 full sync + incremental sync 验证：目标 RPC 先打 follower FE，日志出现 `switch to master 10.200.2.2:19020`，restore finished，随后增量行复制成功。