### PR TITLE
[build](build) Bump version to hydcp-1.2-rc02

### DIFF
--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -32,7 +32,7 @@ build_version_major="${DORIS_BUILD_VERSION_MAJOR-3}"
 build_version_minor="${DORIS_BUILD_VERSION_MINOR-1}"
 build_version_patch="${DORIS_BUILD_VERSION_PATCH-4}"
 build_version_hotfix="${DORIS_BUILD_VERSION_HOTFIX-0}"
-build_version_rc_version="${DORIS_BUILD_VERSION_RC_VERSION-"hydcp-1.2-rc01"}"
+build_version_rc_version="${DORIS_BUILD_VERSION_RC_VERSION-"hydcp-1.2-rc02"}"
 
 build_version="${build_version_prefix}-${build_version_major}.${build_version_minor}.${build_version_patch}"
 if [[ ${build_version_hotfix} -gt 0 ]]; then


### PR DESCRIPTION
## Summary
Update the default RC version string from hydcp-1.2-rc01 to hydcp-1.2-rc02.

## Scope
This change only updates the build version metadata in gen_build_version.sh.

## Test
- bash -n gensrc/script/gen_build_version.sh