### PR TITLE
[improvement](fe) Disable profile for insert into values and other commands

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
@@ -137,6 +137,8 @@ public abstract class AbstractInsertExecutor {
         this.jobId = jobId;
         coordinator.setLoadZeroTolerance(ctx.getSessionVariable().getEnableInsertStrict());
         coordinator.setQueryType(TQueryType.LOAD);
+        // Reuse the executor-level statement check before registering the execution profile.
+        coordinator.setIsProfileSafeStmt(executor.isProfileSafeStmt());
         executor.getProfile().addExecutionProfile(coordinator.getExecutionProfile());
         QueryInfo queryInfo = new QueryInfo(ConnectContext.get(), executor.getOriginStmtInString(), coordinator);
         QeProcessorImpl.INSTANCE.registerQuery(ctx.queryId(), queryInfo);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/CoordInterface.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/CoordInterface.java
@@ -35,4 +35,7 @@ public interface CoordInterface {
     public default void close() {}
 
     List<TNetworkAddress> getInvolvedBackends();
+
+    // Propagate whether the current statement should keep profile collection enabled.
+    void setIsProfileSafeStmt(boolean isSafe);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -3433,5 +3433,10 @@ public class Coordinator implements CoordInterface {
             this.targetFragmentInstanceAddr = host;
         }
     }
-}
 
+    // Disable execution profile creation at the coordinator entry when the statement is not profile-safe.
+    @Override
+    public void setIsProfileSafeStmt(boolean isSafe) {
+        this.queryOptions.setEnableProfile(isSafe && queryOptions.isEnableProfile());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/PointQueryExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/PointQueryExecutor.java
@@ -379,4 +379,10 @@ public class PointQueryExecutor implements CoordInterface {
     public List<TNetworkAddress> getInvolvedBackends() {
         return Lists.newArrayList();
     }
+
+    // Keep point-query execution unchanged because it does not maintain execution profiles here.
+    @Override
+    public void setIsProfileSafeStmt(boolean isSafe) {
+        // Do nothing
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -141,6 +141,8 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.PlanProcess;
 import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.analyzer.UnboundBaseExternalTableSink;
+import org.apache.doris.nereids.analyzer.UnboundTableSink;
 import org.apache.doris.nereids.exceptions.MustFallbackException;
 import org.apache.doris.nereids.exceptions.ParseException;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
@@ -150,13 +152,16 @@ import org.apache.doris.nereids.trees.expressions.Placeholder;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
+import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PrepareCommandPlanner;
+import org.apache.doris.nereids.trees.plans.algebra.InlineTable;
 import org.apache.doris.nereids.trees.plans.commands.Command;
 import org.apache.doris.nereids.trees.plans.commands.CreatePolicyCommand;
 import org.apache.doris.nereids.trees.plans.commands.CreateTableCommand;
 import org.apache.doris.nereids.trees.plans.commands.DeleteFromCommand;
 import org.apache.doris.nereids.trees.plans.commands.DeleteFromUsingCommand;
 import org.apache.doris.nereids.trees.plans.commands.Forward;
+import org.apache.doris.nereids.trees.plans.commands.LoadCommand;
 import org.apache.doris.nereids.trees.plans.commands.PrepareCommand;
 import org.apache.doris.nereids.trees.plans.commands.UnsupportedCommand;
 import org.apache.doris.nereids.trees.plans.commands.UpdateCommand;
@@ -1267,6 +1272,46 @@ public class StmtExecutor {
                 && !(((LogicalPlanAdapter) parsedStmt).getLogicalPlan() instanceof Command));
     }
 
+    // Keep execution profiles only for statements that provide useful runtime diagnostics.
+    public boolean isProfileSafeStmt() {
+        // Only generate profiles for statements analyzed by the Nereids planner.
+        if (!(parsedStmt instanceof LogicalPlanAdapter)) {
+            return false;
+        }
+
+        LogicalPlan plan = ((LogicalPlanAdapter) parsedStmt).getLogicalPlan();
+
+        if (plan instanceof InsertIntoTableCommand) {
+            LogicalPlan logicalPlan = ((InsertIntoTableCommand) plan).getLogicalQuery();
+            // Disable profiles for INSERT INTO ... VALUES because they add noise without useful execution insight.
+            if ((logicalPlan instanceof UnboundTableSink)
+                    || (logicalPlan instanceof UnboundBaseExternalTableSink)) {
+                if (logicalPlan.children().isEmpty()) {
+                    return false;
+                }
+
+                for (Plan child : logicalPlan.children()) {
+                    // InlineTable indicates INSERT INTO ... VALUES.
+                    if (child instanceof InlineTable) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        // Keep profiles for CREATE TABLE AS SELECT, LOAD and INSERT OVERWRITE statements.
+        if ((plan instanceof Command) && !(plan instanceof LoadCommand)
+                && !(plan instanceof CreateTableCommand)
+                && !(plan instanceof InsertOverwriteTableCommand)) {
+            // Commands like SHOW QUERY PROFILE should not create profiles for themselves.
+            return false;
+        } else {
+            // Keep profiles for all remaining statements.
+            return true;
+        }
+    }
+
     private void forwardToMaster() throws Exception {
         masterOpExecutor = new MasterOpExecutor(originStmt, context, redirectStatus, isQuery());
         if (LOG.isDebugEnabled()) {
@@ -1302,7 +1347,8 @@ public class StmtExecutor {
     }
 
     public void updateProfile(boolean isFinished) {
-        if (!context.getSessionVariable().enableProfile()) {
+        // Guard FE-side profile updates for statements that should not expose execution profiles.
+        if (!context.getSessionVariable().enableProfile() || !isProfileSafeStmt()) {
             return;
         }
         // If any error happened in update profile, we should ignore this error
@@ -1951,6 +1997,9 @@ public class StmtExecutor {
                     new QueryInfo(context, originStmt.originStmt, coord));
             coordBase = coord;
         }
+
+        // Disable BE profile collection before execution for statements that are not profile-safe.
+        coordBase.setIsProfileSafeStmt(this.isProfileSafeStmt());
 
         try {
             coordBase.exec();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutorTest.java
@@ -99,6 +99,8 @@ public class OlapInsertExecutorTest extends TestWithFeService {
             Assertions.assertEquals(12L, insertResult.loadedRows);
             Assertions.assertEquals(1L, insertResult.filteredRows);
             Assertions.assertEquals(12L, ctx.getReturnRows());
+            // Verify the insert path propagates the profile-safe decision before coordinator execution.
+            Mockito.verify(coordinator).setIsProfileSafeStmt(false);
 
             // The finished load job must still be recorded even when the client response becomes ERR.
             ArgumentCaptor<String> failMsgCaptor = ArgumentCaptor.forClass(String.class);
@@ -210,6 +212,8 @@ public class OlapInsertExecutorTest extends TestWithFeService {
         StmtExecutor stmtExecutor = Mockito.mock(StmtExecutor.class);
         Mockito.when(stmtExecutor.getProfile()).thenReturn(Mockito.mock(Profile.class));
         Mockito.when(stmtExecutor.getOriginStmtInString()).thenReturn("insert into test_tbl select 1");
+        // Force the executor to mark this mocked insert as profile-unsafe so the propagation can be asserted.
+        Mockito.when(stmtExecutor.isProfileSafeStmt()).thenReturn(false);
         return stmtExecutor;
     }
 

--- a/regression-test/suites/query_profile/profile_safe.groovy
+++ b/regression-test/suites/query_profile/profile_safe.groovy
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import groovy.json.JsonSlurper
+
+def getProfileList = { masterHTTPAddr ->
+    def dst = 'http://' + masterHTTPAddr
+    def conn = new URL(dst + "/rest/v1/query_profile").openConnection()
+    conn.setRequestMethod("GET")
+    def encoding = Base64.getEncoder().encodeToString(
+            (context.config.feHttpUser + ":" + (context.config.feHttpPassword == null
+                    ? "" : context.config.feHttpPassword)).getBytes("UTF-8"))
+    conn.setRequestProperty("Authorization", "Basic ${encoding}")
+    return conn.getInputStream().getText()
+}
+
+suite('profile_safe') {
+    sql """set enable_profile = true;"""
+
+    // Verify that SHOW QUERY PROFILE does not create profile entries for itself.
+    for (int i = 0; i < 10; i++) {
+        sql """show query profile;"""
+    }
+    def res1 = sql "show query profile;"
+    def profileCounts = res1.size()
+    for (int i = 0; i < profileCounts; i++) {
+        def stmt = res1[i][-1]
+        assert !stmt.contains("show query profile")
+    }
+
+    def allFrontends = sql """show frontends;"""
+    logger.info("allFrontends: " + allFrontends)
+    def frontendCounts = allFrontends.size()
+    def masterIP = ""
+    def masterHTTPPort = ""
+
+    for (def i = 0; i < frontendCounts; i++) {
+        def currentFrontend = allFrontends[i]
+        def isMaster = currentFrontend[8]
+        if (isMaster == "true") {
+            masterIP = allFrontends[i][1]
+            masterHTTPPort = allFrontends[i][3]
+            break
+        }
+    }
+    def masterAddress = masterIP + ":" + masterHTTPPort
+    logger.info("masterIP:masterHTTPPort is:${masterAddress}")
+
+    sql """drop table if exists profile_safe;"""
+    sql """create table profile_safe (k1 INT, v1 VARCHAR)
+            distributed by hash(k1) buckets 8 properties("replication_num"="1");"""
+    // Verify that INSERT INTO ... VALUES does not create profile entries.
+    sql """ INSERT INTO profile_safe VALUES (1, 'test_profile_safe'),(2, 'test_profile_safe');"""
+    Thread.sleep(200)
+    def wholeString = getProfileList(masterAddress)
+    def profileListData = new JsonSlurper().parseText(wholeString).data.rows
+    for (def profileList : profileListData) {
+        def stmt = profileList["Sql Statement"].toString()
+        if (stmt.contains("INSERT INTO profile_safe VALUES")) {
+            logger.info("stmt is: ${stmt}")
+        }
+        assert !stmt.contains("INSERT INTO profile_safe VALUES")
+    }
+
+    // Verify that INSERT INTO ... SELECT still keeps its LOAD profile.
+    sql """ INSERT INTO profile_safe SELECT * FROM profile_safe;"""
+    boolean hasInsertSelectProfile = false
+    for (int i = 0; i < 10; i++) {
+        Thread.sleep(500)
+        wholeString = getProfileList(masterAddress)
+        profileListData = new JsonSlurper().parseText(wholeString).data.rows
+        for (def profileList : profileListData) {
+            def taskType = profileList["Task Type"].toString()
+            def stmt = profileList["Sql Statement"].toString()
+            if (taskType == "LOAD" && stmt.contains("INSERT INTO profile_safe SELECT * FROM profile_safe")) {
+                hasInsertSelectProfile = true
+                break
+            }
+        }
+        if (hasInsertSelectProfile == true) {
+            break
+        }
+    }
+    assertTrue(hasInsertSelectProfile)
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: N/A

Related PR: #47296

- backport master PR #47296 to branch-3.1
- disable profile generation for insert into values and other profile-safe statements
- add FE unit test coverage and profile_safe regression test

## Validation

- FE UT: `./run-fe-ut.sh --run org.apache.doris.nereids.trees.plans.commands.insert.OlapInsertExecutorTest`
- FE build: `./build.sh --fe`
- Regression: `./run-regression-test.sh --run -d query_profile -s profile_safe`