### PR TITLE
[fix](backup) clean backup local job dir after completion

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/GZIPUtils.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/GZIPUtils.java
@@ -23,8 +23,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -43,10 +45,22 @@ public class GZIPUtils {
     }
 
     public static byte[] compress(File file) throws IOException {
+        return compress(file, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Stream-compress {@code file} with an 8KB read buffer.
+     * Fails fast if the compressed output would exceed {@code maxCompressedSize}
+     * so callers can avoid unbounded FE heap growth.
+     */
+    public static byte[] compress(File file, int maxCompressedSize) throws IOException {
+        if (maxCompressedSize <= 0) {
+            throw new IOException("maxCompressedSize must be positive, got " + maxCompressedSize);
+        }
         ByteArrayOutputStream bytesStream = new ByteArrayOutputStream();
         try (FileInputStream fileInputStream = new FileInputStream(file);
-                GZIPOutputStream gzipStream = new GZIPOutputStream(bytesStream)) {
-
+                GZIPOutputStream gzipStream = new GZIPOutputStream(
+                        new BoundedSizeOutputStream(bytesStream, maxCompressedSize))) {
             byte[] buffer = new byte[8192]; // 8KB buffer
             int bytesRead;
             while ((bytesRead = fileInputStream.read(buffer)) != -1) {
@@ -65,5 +79,40 @@ public class GZIPUtils {
 
     public static InputStream lazyDecompress(byte[] data) throws IOException {
         return new GZIPInputStream(new ByteArrayInputStream(data));
+    }
+
+    /**
+     * Counts written bytes and rejects writes that would exceed {@code maxSize}.
+     * Used so gzip can fail during streaming instead of after a multi-GB buffer is filled.
+     */
+    private static final class BoundedSizeOutputStream extends FilterOutputStream {
+        private final int maxSize;
+        private int written;
+
+        BoundedSizeOutputStream(OutputStream out, int maxSize) {
+            super(out);
+            this.maxSize = maxSize;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            ensureCapacity(1);
+            out.write(b);
+            written++;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            ensureCapacity(len);
+            out.write(b, off, len);
+            written += len;
+        }
+
+        private void ensureCapacity(int len) throws IOException {
+            if (len < 0 || (long) written + len > maxSize) {
+                throw new IOException(
+                        String.format("compressed size exceeds limit %d bytes", maxSize));
+            }
+        }
     }
 }

--- a/fe/fe-common/src/test/java/org/apache/doris/common/GZIPUtilsTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/GZIPUtilsTest.java
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Random;
+
+public class GZIPUtilsTest {
+    @Test
+    public void testCompressFileRespectsMaxCompressedSize() throws IOException {
+        File file = File.createTempFile("gzip_utils_bound_", ".bin");
+        file.deleteOnExit();
+        // Low-compressibility payload so compressed size stays close to input size.
+        byte[] payload = new byte[64 * 1024];
+        new Random(0).nextBytes(payload);
+        Files.write(file.toPath(), payload);
+
+        byte[] compressed = GZIPUtils.compress(file, Integer.MAX_VALUE);
+        Assert.assertTrue(GZIPUtils.isGZIPCompressed(compressed));
+        Assert.assertArrayEquals(payload, GZIPUtils.decompress(compressed));
+
+        try {
+            GZIPUtils.compress(file, 32);
+            Assert.fail("expected IOException when compressed size exceeds limit");
+        } catch (IOException e) {
+            Assert.assertTrue(e.getMessage().contains("compressed size exceeds limit"));
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -974,7 +974,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
         }
     }
 
-    public Snapshot getSnapshot(String labelName, boolean enableCompress) {
+    public Snapshot getSnapshot(String labelName, boolean enableCompress) throws IOException {
         BackupJob backupJob;
         localSnapshotsLock.readLock().lock();
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -203,6 +203,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
             job.setEnv(env);
             job.run();
         }
+        cleanupBackupJobLocalJobDirs();
     }
 
     // handle create repository stmt
@@ -642,14 +643,14 @@ public class BackupHandler extends MasterDaemon implements Writable {
             return;
         }
 
-        List<String> removedLabels = Lists.newArrayList();
+        List<BackupJob> removedBackupJobs = Lists.newArrayList();
         jobLock.lock();
         try {
             Deque<AbstractJob> jobs = dbIdToBackupOrRestoreJobs.computeIfAbsent(dbId, k -> Lists.newLinkedList());
             while (jobs.size() >= Config.max_backup_restore_job_num_per_db) {
                 AbstractJob removedJob = jobs.removeFirst();
-                if (removedJob instanceof BackupJob && ((BackupJob) removedJob).isLocalSnapshot()) {
-                    removedLabels.add(removedJob.getLabel());
+                if (removedJob instanceof BackupJob) {
+                    removedBackupJobs.add((BackupJob) removedJob);
                 }
             }
             AbstractJob lastJob = jobs.peekLast();
@@ -671,8 +672,11 @@ public class BackupHandler extends MasterDaemon implements Writable {
                 addSnapshot(backupJob.getLabel(), backupJob);
             }
         }
-        for (String label : removedLabels) {
-            removeSnapshot(label);
+        for (BackupJob removedBackupJob : removedBackupJobs) {
+            if (removedBackupJob.isLocalSnapshot()) {
+                removeSnapshot(removedBackupJob.getLabel());
+            }
+            removedBackupJob.cleanupLocalJobDirAfterRemoved();
         }
     }
 
@@ -683,6 +687,24 @@ public class BackupHandler extends MasterDaemon implements Writable {
                     .map(Deque::getLast).collect(Collectors.toList());
         } finally {
             jobLock.unlock();
+        }
+    }
+
+    private List<AbstractJob> getAllJobs() {
+        jobLock.lock();
+        try {
+            return dbIdToBackupOrRestoreJobs.values().stream().flatMap(Deque::stream).collect(Collectors.toList());
+        } finally {
+            jobLock.unlock();
+        }
+    }
+
+    private void cleanupBackupJobLocalJobDirs() {
+        long nowMs = System.currentTimeMillis();
+        for (AbstractJob job : getAllJobs()) {
+            if (job instanceof BackupJob) {
+                ((BackupJob) job).cleanupLocalJobDirIfNecessary(nowMs);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -974,7 +974,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
         }
     }
 
-    public Snapshot getSnapshot(String labelName) {
+    public Snapshot getSnapshot(String labelName, boolean enableCompress) {
         BackupJob backupJob;
         localSnapshotsLock.readLock().lock();
         try {
@@ -987,7 +987,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
             return null;
         }
 
-        return backupJob.getSnapshot();
+        return backupJob.getSnapshot(enableCompress);
     }
 
     public static BackupHandler read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -36,6 +36,7 @@ import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.View;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeMetaVersion;
+import org.apache.doris.common.GZIPUtils;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.TimeUtils;
@@ -1158,8 +1159,16 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         return commitSeq;
     }
 
-    // read meta and job info bytes from disk, and return the snapshot
-    public synchronized Snapshot getSnapshot() {
+    /**
+     * Materialize a local snapshot for getSnapshot RPC under the job lock.
+     *
+     * <p>Checks original file sizes before any full read. For uncompressed requests
+     * that exceed the thrift ~2GB limit, returns sizes only (no file content).
+     * For compressed requests, stream-compresses from files so uncompressed
+     * byte[] are never fully loaded into heap. Returned Snapshot holds all data
+     * needed by the RPC so the job dir can be cleaned up afterwards.
+     */
+    public synchronized Snapshot getSnapshot(boolean enableCompress) {
         if (state != BackupJobState.FINISHED || repoId != Repository.KEEP_ON_LOCAL_REPO_ID) {
             return null;
         }
@@ -1168,13 +1177,32 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         long expiredAt = createTime + timeoutMs;
         if (System.currentTimeMillis() >= expiredAt) {
             cleanupLocalJobDir();
-            return new Snapshot(label, null, null, expiredAt, commitSeq);
+            return new Snapshot(label, null, null, 0, 0, false, expiredAt, commitSeq);
         }
 
         try {
-            byte[] meta = Files.readAllBytes(Paths.get(localMetaInfoFilePath));
-            byte[] jobInfo = Files.readAllBytes(Paths.get(localJobInfoFilePath));
-            return new Snapshot(label, meta, jobInfo, expiredAt, commitSeq);
+            Path metaPath = Paths.get(localMetaInfoFilePath);
+            Path jobInfoPath = Paths.get(localJobInfoFilePath);
+            long metaSize = Files.size(metaPath);
+            long jobInfoSize = Files.size(jobInfoPath);
+
+            // Uncompressed thrift payload cannot exceed Integer.MAX_VALUE (~2GB).
+            // Reject before reading so FE heap is not blown by large local snapshots.
+            if (!enableCompress && metaSize + jobInfoSize >= Integer.MAX_VALUE) {
+                return new Snapshot(label, null, null, metaSize, jobInfoSize, false, expiredAt, commitSeq);
+            }
+
+            byte[] meta;
+            byte[] jobInfo;
+            if (enableCompress) {
+                // Stream compress from files (8KB buffer); do not load full raw content first.
+                meta = GZIPUtils.compress(metaPath.toFile());
+                jobInfo = GZIPUtils.compress(jobInfoPath.toFile());
+            } else {
+                meta = Files.readAllBytes(metaPath);
+                jobInfo = Files.readAllBytes(jobInfoPath);
+            }
+            return new Snapshot(label, meta, jobInfo, metaSize, jobInfoSize, enableCompress, expiredAt, commitSeq);
         } catch (IOException e) {
             LOG.warn("failed to read local snapshot files. {}", this, e);
             return null;

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -80,6 +80,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
 
@@ -1068,6 +1069,8 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             env.getBackupHandler().addSnapshot(label, this);
             return;
         }
+
+        cleanupLocalJobDir();
     }
 
     private boolean uploadFile(String localFilePath, String remoteFilePath) {
@@ -1130,18 +1133,7 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
                 break;
         }
 
-        // clean the backup job dir
-        if (localJobDirPath != null) {
-            try {
-                File jobDir = new File(localJobDirPath.toString());
-                if (jobDir.exists()) {
-                    Files.walk(localJobDirPath, FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder())
-                            .map(Path::toFile).forEach(File::delete);
-                }
-            } catch (Exception e) {
-                LOG.warn("failed to clean the backup job dir: " + localJobDirPath.toString());
-            }
-        }
+        cleanupLocalJobDir();
 
         // meta info and job info not need save in log when cancel, we need to clean them here
         backupMeta = null;
@@ -1175,12 +1167,79 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         // Avoid loading expired meta.
         long expiredAt = createTime + timeoutMs;
         if (System.currentTimeMillis() >= expiredAt) {
+            cleanupLocalJobDir();
             return new Snapshot(label, null, null, expiredAt, commitSeq);
         }
 
-        File metaInfoFile = new File(localMetaInfoFilePath);
-        File jobInfoFile = new File(localJobInfoFilePath);
-        return new Snapshot(label, metaInfoFile, jobInfoFile, expiredAt, commitSeq);
+        try {
+            byte[] meta = Files.readAllBytes(Paths.get(localMetaInfoFilePath));
+            byte[] jobInfo = Files.readAllBytes(Paths.get(localJobInfoFilePath));
+            return new Snapshot(label, meta, jobInfo, expiredAt, commitSeq);
+        } catch (IOException e) {
+            LOG.warn("failed to read local snapshot files. {}", this, e);
+            return null;
+        }
+    }
+
+    synchronized void cleanupLocalJobDirIfNecessary(long nowMs) {
+        if (repoId != Repository.KEEP_ON_LOCAL_REPO_ID) {
+            if (isDone()) {
+                cleanupLocalJobDir();
+            }
+            return;
+        }
+
+        if (isCancelled() || (isFinished() && nowMs >= createTime + timeoutMs)) {
+            cleanupLocalJobDir();
+        }
+    }
+
+    synchronized void cleanupLocalJobDirAfterRemoved() {
+        if (isDone()) {
+            cleanupLocalJobDir();
+        }
+    }
+
+    private void cleanupLocalJobDir() {
+        Path jobDirPath = getLocalJobDirPathForCleanup();
+        if (jobDirPath == null) {
+            return;
+        }
+        Path normalizedJobDirPath = jobDirPath.toAbsolutePath().normalize();
+        if (!isValidLocalJobDirForCleanup(normalizedJobDirPath)) {
+            LOG.warn("skip cleaning invalid backup job dir: {}. {}", normalizedJobDirPath, this);
+            return;
+        }
+        try {
+            File jobDir = normalizedJobDirPath.toFile();
+            if (jobDir.exists()) {
+                try (Stream<Path> paths = Files.walk(normalizedJobDirPath)) {
+                    paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+                }
+                LOG.info("cleaned backup job dir: {}. {}", normalizedJobDirPath, this);
+            }
+            localJobDirPath = null;
+        } catch (Exception e) {
+            LOG.warn("failed to clean the backup job dir: {}. {}", normalizedJobDirPath, this, e);
+        }
+    }
+
+    private Path getLocalJobDirPathForCleanup() {
+        if (localJobDirPath != null) {
+            return localJobDirPath;
+        }
+        if (localMetaInfoFilePath != null) {
+            return Paths.get(localMetaInfoFilePath).getParent();
+        }
+        if (localJobInfoFilePath != null) {
+            return Paths.get(localJobInfoFilePath).getParent();
+        }
+        return null;
+    }
+
+    private boolean isValidLocalJobDirForCleanup(Path jobDirPath) {
+        Path backupRootDir = BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize();
+        return jobDirPath.startsWith(backupRootDir) && !jobDirPath.equals(backupRootDir);
     }
 
     public synchronized List<String> getInfo() {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -132,6 +132,14 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     private String localMetaInfoFilePath = null;
     @SerializedName("jifp")
     private String localJobInfoFilePath = null;
+    /**
+     * Coordinates local staging-dir lifetime with getSnapshot materialization.
+     * Separate from the job state monitor so heavy IO does not block BackupJob.run().
+     */
+    private final Object localJobDirLock = new Object();
+    private int localJobDirReaders = 0;
+    private boolean localJobDirCleanupPending = false;
+    private boolean localJobDirCleaned = false;
     // backup properties && table commit seq with table id
     @SerializedName("prop")
     private Map<String, String> properties = Maps.newHashMap();
@@ -1160,52 +1168,85 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     }
 
     /**
-     * Materialize a local snapshot for getSnapshot RPC under the job lock.
+     * Materialize a local snapshot for getSnapshot RPC.
      *
-     * <p>Checks original file sizes before any full read. For uncompressed requests
-     * that exceed the thrift ~2GB limit, returns sizes only (no file content).
-     * For compressed requests, stream-compresses from files so uncompressed
-     * byte[] are never fully loaded into heap. Returned Snapshot holds all data
-     * needed by the RPC so the job dir can be cleaned up afterwards.
+     * <p>Job state is checked under the job monitor only briefly. File lifetime is
+     * protected by a separate reader refcount so heavy IO/compression does not block
+     * {@link #run()} / other jobs on the backup daemon. Uncompressed payloads that
+     * exceed the thrift ~2GB limit are rejected before reading content. Compressed
+     * payloads are stream-compressed with an output size bound. IO failures propagate
+     * as {@link IOException} (not "snapshot not exist").
      */
-    public synchronized Snapshot getSnapshot(boolean enableCompress) {
-        if (state != BackupJobState.FINISHED || repoId != Repository.KEEP_ON_LOCAL_REPO_ID) {
+    public Snapshot getSnapshot(boolean enableCompress) throws IOException {
+        final String metaPathStr;
+        final String jobInfoPathStr;
+        final long expiredAt;
+        final long commitSeqSnapshot;
+        final String snapshotLabel;
+
+        synchronized (this) {
+            if (state != BackupJobState.FINISHED || repoId != Repository.KEEP_ON_LOCAL_REPO_ID) {
+                return null;
+            }
+
+            // Avoid loading expired meta.
+            expiredAt = createTime + timeoutMs;
+            if (System.currentTimeMillis() >= expiredAt) {
+                cleanupLocalJobDir();
+                return new Snapshot(label, null, null, 0, 0, false, expiredAt, commitSeq);
+            }
+            metaPathStr = localMetaInfoFilePath;
+            jobInfoPathStr = localJobInfoFilePath;
+            commitSeqSnapshot = commitSeq;
+            snapshotLabel = label;
+        }
+
+        if (metaPathStr == null || jobInfoPathStr == null) {
+            return null;
+        }
+        if (!acquireLocalJobDirRead()) {
+            // Dir already cleaned or never created.
             return null;
         }
 
-        // Avoid loading expired meta.
-        long expiredAt = createTime + timeoutMs;
-        if (System.currentTimeMillis() >= expiredAt) {
-            cleanupLocalJobDir();
-            return new Snapshot(label, null, null, 0, 0, false, expiredAt, commitSeq);
-        }
-
         try {
-            Path metaPath = Paths.get(localMetaInfoFilePath);
-            Path jobInfoPath = Paths.get(localJobInfoFilePath);
+            Path metaPath = Paths.get(metaPathStr);
+            Path jobInfoPath = Paths.get(jobInfoPathStr);
             long metaSize = Files.size(metaPath);
             long jobInfoSize = Files.size(jobInfoPath);
 
             // Uncompressed thrift payload cannot exceed Integer.MAX_VALUE (~2GB).
             // Reject before reading so FE heap is not blown by large local snapshots.
             if (!enableCompress && metaSize + jobInfoSize >= Integer.MAX_VALUE) {
-                return new Snapshot(label, null, null, metaSize, jobInfoSize, false, expiredAt, commitSeq);
+                return new Snapshot(snapshotLabel, null, null, metaSize, jobInfoSize, false, expiredAt,
+                        commitSeqSnapshot);
             }
 
             byte[] meta;
             byte[] jobInfo;
             if (enableCompress) {
-                // Stream compress from files (8KB buffer); do not load full raw content first.
-                meta = GZIPUtils.compress(metaPath.toFile());
-                jobInfo = GZIPUtils.compress(jobInfoPath.toFile());
+                // Stream compress with a hard cap so low-compressibility data cannot
+                // grow an unbounded ByteArrayOutputStream on the FE heap.
+                meta = GZIPUtils.compress(metaPath.toFile(), Integer.MAX_VALUE);
+                int remaining = Integer.MAX_VALUE - meta.length;
+                if (remaining <= 0) {
+                    throw new IOException(String.format(
+                            "Compressed snapshot meta alone is too large (%d bytes >= 2GB).", meta.length));
+                }
+                jobInfo = GZIPUtils.compress(jobInfoPath.toFile(), remaining);
+                if ((long) meta.length + jobInfo.length >= Integer.MAX_VALUE) {
+                    throw new IOException(String.format(
+                            "Compressed snapshot is too large (%d bytes >= 2GB).",
+                            (long) meta.length + jobInfo.length));
+                }
             } else {
                 meta = Files.readAllBytes(metaPath);
                 jobInfo = Files.readAllBytes(jobInfoPath);
             }
-            return new Snapshot(label, meta, jobInfo, metaSize, jobInfoSize, enableCompress, expiredAt, commitSeq);
-        } catch (IOException e) {
-            LOG.warn("failed to read local snapshot files. {}", this, e);
-            return null;
+            return new Snapshot(snapshotLabel, meta, jobInfo, metaSize, jobInfoSize, enableCompress, expiredAt,
+                    commitSeqSnapshot);
+        } finally {
+            releaseLocalJobDirRead();
         }
     }
 
@@ -1228,9 +1269,53 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         }
     }
 
+    /**
+     * Delete local staging dir when no getSnapshot reader is active; otherwise defer
+     * until the last reader releases. Must not run heavy IO while holding the job monitor
+     * for longer than the brief synchronized callers already do — deletion itself uses
+     * {@link #localJobDirLock} only.
+     */
     private void cleanupLocalJobDir() {
+        synchronized (localJobDirLock) {
+            if (localJobDirCleaned) {
+                return;
+            }
+            if (localJobDirReaders > 0) {
+                localJobDirCleanupPending = true;
+                return;
+            }
+            cleanupLocalJobDirUnderLock();
+        }
+    }
+
+    private boolean acquireLocalJobDirRead() {
+        synchronized (localJobDirLock) {
+            if (localJobDirCleaned) {
+                return false;
+            }
+            if (getLocalJobDirPathForCleanup() == null) {
+                return false;
+            }
+            localJobDirReaders++;
+            return true;
+        }
+    }
+
+    private void releaseLocalJobDirRead() {
+        synchronized (localJobDirLock) {
+            localJobDirReaders--;
+            if (localJobDirReaders == 0 && localJobDirCleanupPending) {
+                cleanupLocalJobDirUnderLock();
+            }
+        }
+    }
+
+    /** Caller must hold {@link #localJobDirLock}. */
+    private void cleanupLocalJobDirUnderLock() {
+        localJobDirCleanupPending = false;
         Path jobDirPath = getLocalJobDirPathForCleanup();
         if (jobDirPath == null) {
+            localJobDirCleaned = true;
             return;
         }
         Path normalizedJobDirPath = jobDirPath.toAbsolutePath().normalize();
@@ -1247,6 +1332,7 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
                 LOG.info("cleaned backup job dir: {}. {}", normalizedJobDirPath, this);
             }
             localJobDirPath = null;
+            localJobDirCleaned = true;
         } catch (Exception e) {
             LOG.warn("failed to clean the backup job dir: {}. {}", normalizedJobDirPath, this, e);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -1326,15 +1326,22 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         try {
             File jobDir = normalizedJobDirPath.toFile();
             if (jobDir.exists()) {
-                try (Stream<Path> paths = Files.walk(normalizedJobDirPath)) {
-                    paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-                }
+                deleteLocalJobDir(normalizedJobDirPath);
                 LOG.info("cleaned backup job dir: {}. {}", normalizedJobDirPath, this);
             }
             localJobDirPath = null;
             localJobDirCleaned = true;
         } catch (Exception e) {
             LOG.warn("failed to clean the backup job dir: {}. {}", normalizedJobDirPath, this, e);
+        }
+    }
+
+    void deleteLocalJobDir(Path jobDirPath) throws IOException {
+        try (Stream<Path> paths = Files.walk(jobDirPath)) {
+            List<Path> pathsToDelete = paths.sorted(Comparator.reverseOrder()).collect(Collectors.toList());
+            for (Path path : pathsToDelete) {
+                Files.deleteIfExists(path);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -1178,11 +1178,13 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
      * as {@link IOException} (not "snapshot not exist").
      */
     public Snapshot getSnapshot(boolean enableCompress) throws IOException {
-        final String metaPathStr;
-        final String jobInfoPathStr;
-        final long expiredAt;
-        final long commitSeqSnapshot;
-        final String snapshotLabel;
+        String metaPathStr = null;
+        String jobInfoPathStr = null;
+        long expiredAt = 0;
+        long commitSeqSnapshot = 0;
+        String snapshotLabel = null;
+        Snapshot expiredSnapshot = null;
+        boolean pinned = false;
 
         synchronized (this) {
             if (state != BackupJobState.FINISHED || repoId != Repository.KEEP_ON_LOCAL_REPO_ID) {
@@ -1192,21 +1194,26 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             // Avoid loading expired meta.
             expiredAt = createTime + timeoutMs;
             if (System.currentTimeMillis() >= expiredAt) {
-                cleanupLocalJobDir();
-                return new Snapshot(label, null, null, 0, 0, false, expiredAt, commitSeq);
+                expiredSnapshot = new Snapshot(label, null, null, 0, 0, false, expiredAt, commitSeq);
+            } else {
+                metaPathStr = localMetaInfoFilePath;
+                jobInfoPathStr = localJobInfoFilePath;
+                if (metaPathStr == null || jobInfoPathStr == null) {
+                    return null;
+                }
+                if (!acquireLocalJobDirRead()) {
+                    // Dir already cleaned or never created.
+                    return null;
+                }
+                pinned = true;
+                commitSeqSnapshot = commitSeq;
+                snapshotLabel = label;
             }
-            metaPathStr = localMetaInfoFilePath;
-            jobInfoPathStr = localJobInfoFilePath;
-            commitSeqSnapshot = commitSeq;
-            snapshotLabel = label;
         }
 
-        if (metaPathStr == null || jobInfoPathStr == null) {
-            return null;
-        }
-        if (!acquireLocalJobDirRead()) {
-            // Dir already cleaned or never created.
-            return null;
+        if (expiredSnapshot != null) {
+            cleanupLocalJobDir();
+            return expiredSnapshot;
         }
 
         try {
@@ -1246,25 +1253,37 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             return new Snapshot(snapshotLabel, meta, jobInfo, metaSize, jobInfoSize, enableCompress, expiredAt,
                     commitSeqSnapshot);
         } finally {
-            releaseLocalJobDirRead();
+            if (pinned) {
+                releaseLocalJobDirRead();
+            }
         }
     }
 
-    synchronized void cleanupLocalJobDirIfNecessary(long nowMs) {
-        if (repoId != Repository.KEEP_ON_LOCAL_REPO_ID) {
-            if (isDone()) {
-                cleanupLocalJobDir();
+    void cleanupLocalJobDirIfNecessary(long nowMs) {
+        boolean shouldCleanup;
+        synchronized (this) {
+            if (repoId != Repository.KEEP_ON_LOCAL_REPO_ID) {
+                shouldCleanup = isDone();
+            } else {
+                shouldCleanup = isCancelled() || (isFinished() && nowMs >= createTime + timeoutMs);
             }
-            return;
         }
-
-        if (isCancelled() || (isFinished() && nowMs >= createTime + timeoutMs)) {
+        if (shouldCleanup) {
             cleanupLocalJobDir();
         }
     }
 
-    synchronized void cleanupLocalJobDirAfterRemoved() {
-        if (isDone()) {
+    /**
+     * Clean up local staging dir after this job is evicted from the per-db deque.
+     * Local snapshot lifetime is bounded by both {@link #timeoutMs} and
+     * {@code max_backup_restore_job_num_per_db} queue eviction.
+     */
+    void cleanupLocalJobDirAfterRemoved() {
+        boolean shouldCleanup;
+        synchronized (this) {
+            shouldCleanup = isDone();
+        }
+        if (shouldCleanup) {
             cleanupLocalJobDir();
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Snapshot.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Snapshot.java
@@ -22,17 +22,15 @@ import org.apache.doris.common.Pair;
 
 import com.google.gson.annotations.SerializedName;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 
 public class Snapshot {
     @SerializedName(value = "label")
     private String label = null;
 
-    private File meta = null;
+    private byte[] meta = null;
 
-    private File jobInfo = null;
+    private byte[] jobInfo = null;
 
     @SerializedName(value = "expired_at")
     private long expiredAt = 0;
@@ -43,7 +41,7 @@ public class Snapshot {
     public Snapshot() {
     }
 
-    public Snapshot(String label, File meta, File jobInfo, long expiredAt, long commitSeq) {
+    public Snapshot(String label, byte[] meta, byte[] jobInfo, long expiredAt, long commitSeq) {
         this.label = label;
         this.meta = meta;
         this.jobInfo = jobInfo;
@@ -69,11 +67,11 @@ public class Snapshot {
     }
 
     public long getMetaSize() {
-        return meta != null ? meta.length() : 0;
+        return meta != null ? meta.length : 0;
     }
 
     public long getJobInfoSize() {
-        return jobInfo != null ? jobInfo.length() : 0;
+        return jobInfo != null ? jobInfo.length : 0;
     }
 
     public byte[] getCompressedMeta() throws IOException {
@@ -85,11 +83,11 @@ public class Snapshot {
     }
 
     public byte[] getMeta() throws IOException {
-        return Files.readAllBytes(meta.toPath());
+        return meta;
     }
 
     public byte[] getJobInfo() throws IOException {
-        return Files.readAllBytes(jobInfo.toPath());
+        return jobInfo;
     }
 
     public long getExpiredAt() {
@@ -97,7 +95,7 @@ public class Snapshot {
     }
 
     public boolean isExpired() {
-        return System.currentTimeMillis() > expiredAt;
+        return System.currentTimeMillis() >= expiredAt;
     }
 
     public long getCommitSeq() {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Snapshot.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Snapshot.java
@@ -24,6 +24,13 @@ import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;
 
+/**
+ * Materialized local backup snapshot for getSnapshot RPC.
+ *
+ * <p>meta/jobInfo hold the response payload (raw or already gzip-compressed).
+ * metaSize/jobInfoSize are the original on-disk sizes used by the 2GB RPC guard
+ * and logging. After construction, callers must not access the original files.
+ */
 public class Snapshot {
     @SerializedName(value = "label")
     private String label = null;
@@ -31,6 +38,12 @@ public class Snapshot {
     private byte[] meta = null;
 
     private byte[] jobInfo = null;
+
+    private long metaSize = 0;
+
+    private long jobInfoSize = 0;
+
+    private boolean compressed = false;
 
     @SerializedName(value = "expired_at")
     private long expiredAt = 0;
@@ -41,10 +54,14 @@ public class Snapshot {
     public Snapshot() {
     }
 
-    public Snapshot(String label, byte[] meta, byte[] jobInfo, long expiredAt, long commitSeq) {
+    public Snapshot(String label, byte[] meta, byte[] jobInfo, long metaSize, long jobInfoSize,
+            boolean compressed, long expiredAt, long commitSeq) {
         this.label = label;
         this.meta = meta;
         this.jobInfo = jobInfo;
+        this.metaSize = metaSize;
+        this.jobInfoSize = jobInfoSize;
+        this.compressed = compressed;
         this.expiredAt = expiredAt;
         this.commitSeq = commitSeq;
     }
@@ -66,28 +83,32 @@ public class Snapshot {
         return GZIPUtils.isGZIPCompressed(jobInfo) || GZIPUtils.isGZIPCompressed(meta);
     }
 
+    /**
+     * Original on-disk meta size, not necessarily {@code meta.length}.
+     * Used by the uncompressed 2GB RPC guard before any content is returned.
+     */
     public long getMetaSize() {
-        return meta != null ? meta.length : 0;
+        return metaSize;
     }
 
+    /**
+     * Original on-disk job info size, not necessarily {@code jobInfo.length}.
+     * Used by the uncompressed 2GB RPC guard before any content is returned.
+     */
     public long getJobInfoSize() {
-        return jobInfo != null ? jobInfo.length : 0;
+        return jobInfoSize;
     }
 
-    public byte[] getCompressedMeta() throws IOException {
-        return GZIPUtils.compress(meta);
-    }
-
-    public byte[] getCompressedJobInfo() throws IOException {
-        return GZIPUtils.compress(jobInfo);
-    }
-
-    public byte[] getMeta() throws IOException {
+    public byte[] getMeta() {
         return meta;
     }
 
-    public byte[] getJobInfo() throws IOException {
+    public byte[] getJobInfo() {
         return jobInfo;
+    }
+
+    public boolean isCompressed() {
+        return compressed;
     }
 
     public long getExpiredAt() {
@@ -106,6 +127,9 @@ public class Snapshot {
     public String toString() {
         return "Snapshot{"
                 + "label='" + label + '\''
+                + ", metaSize=" + metaSize
+                + ", jobInfoSize=" + jobInfoSize
+                + ", compressed=" + compressed
                 + ", expiredAt=" + expiredAt
                 + ", commitSeq=" + commitSeq
                 + '}';

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -3134,7 +3134,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TGetSnapshotResult result = new TGetSnapshotResult();
         result.setStatus(new TStatus(TStatusCode.OK));
         boolean enableCompress = request.isEnableCompress();
-        // Materialize (or size-check) under BackupJob lock; do not re-read files after return.
+        // Materialize (or size-check) with file refcount; IOException propagates as INTERNAL_ERROR.
+        // Do not re-read files after return.
         Snapshot snapshot = Env.getCurrentEnv().getBackupHandler().getSnapshot(label, enableCompress);
         if (snapshot == null) {
             result.getStatus().setStatusCode(TStatusCode.SNAPSHOT_NOT_EXIST);

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -3133,7 +3133,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         String label = request.getLabelName();
         TGetSnapshotResult result = new TGetSnapshotResult();
         result.setStatus(new TStatus(TStatusCode.OK));
-        Snapshot snapshot = Env.getCurrentEnv().getBackupHandler().getSnapshot(label);
+        boolean enableCompress = request.isEnableCompress();
+        // Materialize (or size-check) under BackupJob lock; do not re-read files after return.
+        Snapshot snapshot = Env.getCurrentEnv().getBackupHandler().getSnapshot(label, enableCompress);
         if (snapshot == null) {
             result.getStatus().setStatusCode(TStatusCode.SNAPSHOT_NOT_EXIST);
             result.getStatus().addToErrorMsgs(String.format("snapshot %s not exist", label));
@@ -3141,10 +3143,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             result.getStatus().setStatusCode(TStatusCode.SNAPSHOT_EXPIRED);
             result.getStatus().addToErrorMsgs(String.format("snapshot %s is expired", label));
         } else {
+            // Original on-disk sizes. For uncompressed oversized snapshots, BackupJob returns
+            // sizes only (meta/jobInfo are null) so the guard runs without loading content.
             long metaSize = snapshot.getMetaSize();
             long jobInfoSize = snapshot.getJobInfoSize();
-            long snapshotSize = snapshot.getMetaSize() + snapshot.getJobInfoSize();
-            if (metaSize + jobInfoSize >= Integer.MAX_VALUE && !request.isEnableCompress()) {
+            long snapshotSize = metaSize + jobInfoSize;
+            if (snapshotSize >= Integer.MAX_VALUE && !enableCompress) {
                 String msg = String.format(
                         "Snapshot %s is too large (%d bytes > 2GB). Please enable compression to continue.",
                         label, snapshotSize);
@@ -3158,20 +3162,18 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             long commitSeq = snapshot.getCommitSeq();
 
             LOG.info("get snapshot info, snapshot: {}, meta size: {}, job info size: {}, "
-                    + "expired at: {}, commit seq: {}", label, metaSize, jobInfoSize, expiredAt, commitSeq);
-            if (request.isEnableCompress()) {
-                byte[] meta = snapshot.getCompressedMeta();
-                byte[] jobInfo = snapshot.getCompressedJobInfo();
-                result.setMeta(meta);
-                result.setJobInfo(jobInfo);
+                    + "expired at: {}, commit seq: {}, compressed: {}",
+                    label, metaSize, jobInfoSize, expiredAt, commitSeq, snapshot.isCompressed());
+            byte[] meta = snapshot.getMeta();
+            byte[] jobInfo = snapshot.getJobInfo();
+            result.setMeta(meta);
+            result.setJobInfo(jobInfo);
+            if (snapshot.isCompressed()) {
                 result.setCompressed(true);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("get snapshot info with compress, snapshot: {}, compressed meta "
                             + "size {}, compressed job info size {}", label, meta.length, jobInfo.length);
                 }
-            } else {
-                result.setMeta(snapshot.getMeta());
-                result.setJobInfo(snapshot.getJobInfo());
             }
             result.setExpiredAt(expiredAt);
             result.setCommitSeq(commitSeq);

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -576,11 +576,12 @@ public class BackupJobTest {
     }
 
     /**
-     * getSnapshot holds the job lock while materializing; concurrent cleanup must wait
-     * until materialization finishes so the response is not corrupted by mid-read deletion.
+     * Active getSnapshot readers pin the staging dir via refcount; cleanup is deferred
+     * until the last reader releases, so mid-read deletion cannot corrupt materialization.
+     * Job state monitor is not required for this coordination.
      */
     @Test
-    public void testLocalSnapshotCleanupWaitsForGetSnapshotMaterialization() throws Exception {
+    public void testLocalSnapshotCleanupDefersWhileGetSnapshotReaderPinned() throws Exception {
         BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
                 Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
                 env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
@@ -599,48 +600,82 @@ public class BackupJobTest {
         Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
         Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
 
-        java.util.concurrent.CountDownLatch cleanupStarted = new java.util.concurrent.CountDownLatch(1);
-        java.util.concurrent.CountDownLatch snapshotDone = new java.util.concurrent.CountDownLatch(1);
-        java.util.concurrent.atomic.AtomicReference<Snapshot> snapshotRef =
-                new java.util.concurrent.atomic.AtomicReference<>();
-        java.util.concurrent.atomic.AtomicReference<Throwable> errorRef =
-                new java.util.concurrent.atomic.AtomicReference<>();
+        // Simulate an in-flight getSnapshot reader pin.
+        Deencapsulation.setField(localSnapshotJob, "localJobDirReaders", 1);
+        localSnapshotJob.cleanupLocalJobDirAfterRemoved();
+        Assert.assertTrue("cleanup must defer while a reader is pinned", localJobDir.exists());
+        Assert.assertTrue(Deencapsulation.getField(localSnapshotJob, "localJobDirCleanupPending"));
 
-        Thread reader = new Thread(() -> {
-            try {
-                // Hold the job lock briefly so cleanup is forced to wait on the same monitor.
-                synchronized (localSnapshotJob) {
-                    cleanupStarted.countDown();
-                    Thread.sleep(200);
-                    snapshotRef.set(localSnapshotJob.getSnapshot(false));
-                }
-                snapshotDone.countDown();
-            } catch (Throwable t) {
-                errorRef.set(t);
-                snapshotDone.countDown();
-            }
-        });
-        Thread cleaner = new Thread(() -> {
-            try {
-                Assert.assertTrue(cleanupStarted.await(5, java.util.concurrent.TimeUnit.SECONDS));
-                localSnapshotJob.cleanupLocalJobDirAfterRemoved();
-            } catch (Throwable t) {
-                errorRef.set(t);
-            }
-        });
-
-        reader.start();
-        cleaner.start();
-        Assert.assertTrue(snapshotDone.await(10, java.util.concurrent.TimeUnit.SECONDS));
-        reader.join(5000);
-        cleaner.join(5000);
-
-        Assert.assertNull(errorRef.get());
-        Snapshot snapshot = snapshotRef.get();
-        Assert.assertNotNull(snapshot);
-        Assert.assertArrayEquals(metaBytes, snapshot.getMeta());
-        Assert.assertArrayEquals(jobInfoBytes, snapshot.getJobInfo());
+        // Release the pin (readers 1 -> 0); deferred cleanup should run.
+        Deencapsulation.invoke(localSnapshotJob, "releaseLocalJobDirRead");
         Assert.assertFalse(localJobDir.exists());
+        Assert.assertTrue(Deencapsulation.getField(localSnapshotJob, "localJobDirCleaned"));
+    }
+
+    @Test
+    public void testLocalSnapshotIoFailurePropagatesAsIOException() throws IOException {
+        BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        File localJobDir = createLocalJobDir("local_snapshot_io_fail");
+        File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-09-17-00-00");
+        Assert.assertTrue(metaInfo.createNewFile());
+        Assert.assertTrue(jobInfo.createNewFile());
+
+        long createTime = System.currentTimeMillis();
+        Deencapsulation.setField(localSnapshotJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(localSnapshotJob, "createTime", createTime);
+        Deencapsulation.setField(localSnapshotJob, "localJobDirPath", null);
+        Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+
+        Assert.assertTrue(metaInfo.delete());
+        try {
+            localSnapshotJob.getSnapshot(false);
+            Assert.fail("expected IOException when meta file is missing");
+        } catch (IOException e) {
+            // Must not be swallowed as null / SNAPSHOT_NOT_EXIST.
+            Assert.assertNotNull(e.getMessage());
+        }
+        // Failed materialization still releases the pin so later cleanup can proceed.
+        localSnapshotJob.cleanupLocalJobDirAfterRemoved();
+        Assert.assertFalse(localJobDir.exists());
+    }
+
+    @Test
+    public void testLocalSnapshotCompressHonorsOutputSizeLimit() throws IOException {
+        BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        File localJobDir = createLocalJobDir("local_snapshot_compress_limit");
+        File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-09-18-00-00");
+        byte[] lowCompress = new byte[128 * 1024];
+        new java.util.Random(1).nextBytes(lowCompress);
+        Files.write(metaInfo.toPath(), lowCompress);
+        Files.write(jobInfo.toPath(), new byte[] {1, 2, 3});
+
+        long createTime = System.currentTimeMillis();
+        Deencapsulation.setField(localSnapshotJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(localSnapshotJob, "createTime", createTime);
+        Deencapsulation.setField(localSnapshotJob, "localJobDirPath", null);
+        Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+
+        // Directly exercise bounded compress used by getSnapshot(true).
+        try {
+            GZIPUtils.compress(metaInfo, 64);
+            Assert.fail("expected compressed size limit to fail on low-compressibility data");
+        } catch (IOException e) {
+            Assert.assertTrue(e.getMessage().contains("compressed size exceeds limit"));
+        }
+
+        // Normal compress path still works with full limit.
+        Snapshot snapshot = localSnapshotJob.getSnapshot(true);
+        Assert.assertNotNull(snapshot);
+        Assert.assertTrue(snapshot.isCompressed());
+        Assert.assertArrayEquals(lowCompress, GZIPUtils.decompress(snapshot.getMeta()));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -32,6 +32,7 @@ import org.apache.doris.catalog.TableProperty;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.GZIPUtils;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.common.util.UnitTestUtil;
@@ -68,6 +69,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -476,12 +478,169 @@ public class BackupJobTest {
         Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
         Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
 
-        Snapshot snapshot = localSnapshotJob.getSnapshot();
+        Snapshot snapshot = localSnapshotJob.getSnapshot(false);
         localSnapshotJob.cleanupLocalJobDirAfterRemoved();
 
         Assert.assertFalse(localJobDir.exists());
+        Assert.assertFalse(snapshot.isCompressed());
+        Assert.assertEquals(metaBytes.length, snapshot.getMetaSize());
+        Assert.assertEquals(jobInfoBytes.length, snapshot.getJobInfoSize());
         Assert.assertArrayEquals(metaBytes, snapshot.getMeta());
         Assert.assertArrayEquals(jobInfoBytes, snapshot.getJobInfo());
+    }
+
+    /**
+     * Oversized local snapshot must not be fully read into FE heap when compression is off.
+     * Sparse files provide a logical size &gt;= Integer.MAX_VALUE without allocating disk/RAM.
+     */
+    @Test
+    public void testLocalSnapshotOversizedWithoutCompressDoesNotReadFiles() throws IOException {
+        BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        File localJobDir = createLocalJobDir("local_snapshot_oversized");
+        File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-09-14-00-00");
+
+        long metaLogicalSize = (long) Integer.MAX_VALUE - 100L;
+        long jobInfoLogicalSize = 100L;
+        createSparseFile(metaInfo, metaLogicalSize);
+        createSparseFile(jobInfo, jobInfoLogicalSize);
+        Assert.assertEquals(metaLogicalSize, metaInfo.length());
+        Assert.assertEquals(jobInfoLogicalSize, jobInfo.length());
+
+        long createTime = System.currentTimeMillis();
+        Deencapsulation.setField(localSnapshotJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(localSnapshotJob, "createTime", createTime);
+        Deencapsulation.setField(localSnapshotJob, "localJobDirPath", null);
+        Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+
+        Snapshot snapshot = localSnapshotJob.getSnapshot(false);
+
+        Assert.assertNotNull(snapshot);
+        Assert.assertFalse(snapshot.isExpired());
+        Assert.assertFalse(snapshot.isCompressed());
+        Assert.assertEquals(metaLogicalSize, snapshot.getMetaSize());
+        Assert.assertEquals(jobInfoLogicalSize, snapshot.getJobInfoSize());
+        Assert.assertTrue(snapshot.getMetaSize() + snapshot.getJobInfoSize() >= Integer.MAX_VALUE);
+        // Content must not be materialized for oversized uncompressed responses.
+        Assert.assertNull(snapshot.getMeta());
+        Assert.assertNull(snapshot.getJobInfo());
+        // Job dir must still exist; size guard rejected before any cleanup side-effect.
+        Assert.assertTrue(localJobDir.exists());
+    }
+
+    @Test
+    public void testLocalSnapshotCompressStreamsFilesAndSurvivesCleanup() throws IOException {
+        BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        File localJobDir = createLocalJobDir("local_snapshot_compress");
+        File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-09-15-00-00");
+        // Slightly compressible payload; enough bytes to exercise streaming path.
+        byte[] metaBytes = new byte[64 * 1024];
+        byte[] jobInfoBytes = new byte[32 * 1024];
+        for (int i = 0; i < metaBytes.length; i++) {
+            metaBytes[i] = (byte) (i % 7);
+        }
+        for (int i = 0; i < jobInfoBytes.length; i++) {
+            jobInfoBytes[i] = (byte) (i % 11);
+        }
+        Files.write(metaInfo.toPath(), metaBytes);
+        Files.write(jobInfo.toPath(), jobInfoBytes);
+
+        long createTime = System.currentTimeMillis();
+        Deencapsulation.setField(localSnapshotJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(localSnapshotJob, "createTime", createTime);
+        Deencapsulation.setField(localSnapshotJob, "localJobDirPath", null);
+        Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+
+        Snapshot snapshot = localSnapshotJob.getSnapshot(true);
+        Assert.assertNotNull(snapshot);
+        Assert.assertTrue(snapshot.isCompressed());
+        Assert.assertEquals(metaBytes.length, snapshot.getMetaSize());
+        Assert.assertEquals(jobInfoBytes.length, snapshot.getJobInfoSize());
+        Assert.assertTrue(GZIPUtils.isGZIPCompressed(snapshot.getMeta()));
+        Assert.assertTrue(GZIPUtils.isGZIPCompressed(snapshot.getJobInfo()));
+        Assert.assertArrayEquals(metaBytes, GZIPUtils.decompress(snapshot.getMeta()));
+        Assert.assertArrayEquals(jobInfoBytes, GZIPUtils.decompress(snapshot.getJobInfo()));
+
+        localSnapshotJob.cleanupLocalJobDirAfterRemoved();
+        Assert.assertFalse(localJobDir.exists());
+        // Materialized compressed payload remains usable after job dir is deleted.
+        Assert.assertArrayEquals(metaBytes, GZIPUtils.decompress(snapshot.getMeta()));
+        Assert.assertArrayEquals(jobInfoBytes, GZIPUtils.decompress(snapshot.getJobInfo()));
+    }
+
+    /**
+     * getSnapshot holds the job lock while materializing; concurrent cleanup must wait
+     * until materialization finishes so the response is not corrupted by mid-read deletion.
+     */
+    @Test
+    public void testLocalSnapshotCleanupWaitsForGetSnapshotMaterialization() throws Exception {
+        BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        File localJobDir = createLocalJobDir("local_snapshot_lock");
+        File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-09-16-00-00");
+        byte[] metaBytes = new byte[] {10, 20, 30, 40};
+        byte[] jobInfoBytes = new byte[] {50, 60, 70};
+        Files.write(metaInfo.toPath(), metaBytes);
+        Files.write(jobInfo.toPath(), jobInfoBytes);
+
+        long createTime = System.currentTimeMillis();
+        Deencapsulation.setField(localSnapshotJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(localSnapshotJob, "createTime", createTime);
+        Deencapsulation.setField(localSnapshotJob, "localJobDirPath", null);
+        Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+
+        java.util.concurrent.CountDownLatch cleanupStarted = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch snapshotDone = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.atomic.AtomicReference<Snapshot> snapshotRef =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        java.util.concurrent.atomic.AtomicReference<Throwable> errorRef =
+                new java.util.concurrent.atomic.AtomicReference<>();
+
+        Thread reader = new Thread(() -> {
+            try {
+                // Hold the job lock briefly so cleanup is forced to wait on the same monitor.
+                synchronized (localSnapshotJob) {
+                    cleanupStarted.countDown();
+                    Thread.sleep(200);
+                    snapshotRef.set(localSnapshotJob.getSnapshot(false));
+                }
+                snapshotDone.countDown();
+            } catch (Throwable t) {
+                errorRef.set(t);
+                snapshotDone.countDown();
+            }
+        });
+        Thread cleaner = new Thread(() -> {
+            try {
+                Assert.assertTrue(cleanupStarted.await(5, java.util.concurrent.TimeUnit.SECONDS));
+                localSnapshotJob.cleanupLocalJobDirAfterRemoved();
+            } catch (Throwable t) {
+                errorRef.set(t);
+            }
+        });
+
+        reader.start();
+        cleaner.start();
+        Assert.assertTrue(snapshotDone.await(10, java.util.concurrent.TimeUnit.SECONDS));
+        reader.join(5000);
+        cleaner.join(5000);
+
+        Assert.assertNull(errorRef.get());
+        Snapshot snapshot = snapshotRef.get();
+        Assert.assertNotNull(snapshot);
+        Assert.assertArrayEquals(metaBytes, snapshot.getMeta());
+        Assert.assertArrayEquals(jobInfoBytes, snapshot.getJobInfo());
+        Assert.assertFalse(localJobDir.exists());
     }
 
     @Test
@@ -749,5 +908,11 @@ public class BackupJobTest {
         Path jobDirPath = BackupHandler.BACKUP_ROOT_DIR.resolve(name + "_" + id.getAndIncrement());
         Files.createDirectories(jobDirPath);
         return jobDirPath.toFile();
+    }
+
+    private void createSparseFile(File file, long logicalSize) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
+            raf.setLength(logicalSize);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -354,6 +354,7 @@ public class BackupJobTest {
         Assert.assertTrue(metaInfo.exists());
         File jobInfo = new File(job.getLocalJobInfoFilePath());
         Assert.assertTrue(jobInfo.exists());
+        File localJobDir = jobInfo.getParentFile();
 
         BackupMeta restoreMetaInfo = null;
         BackupJobInfo restoreJobInfo = null;
@@ -383,6 +384,7 @@ public class BackupJobTest {
         job.run();
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(BackupJobState.FINISHED, job.getState());
+        Assert.assertFalse(localJobDir.exists());
     }
 
     @Test
@@ -409,6 +411,98 @@ public class BackupJobTest {
         Assert.assertNotNull(copied);
         Assert.assertFalse(copied.dynamicPartitionExists());
         Assert.assertTrue(copied.getTableProperty().hasInvalidDynamicPartition());
+    }
+
+    @Test
+    public void testCleanupFinishedRemoteBackupJobDirFromPersistedFilePaths() throws IOException {
+        File localJobDir = createLocalJobDir("remote_cleanup");
+        File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-09-10-00-00");
+        Assert.assertTrue(metaInfo.createNewFile());
+        Assert.assertTrue(jobInfo.createNewFile());
+
+        Deencapsulation.setField(job, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(job, "localJobDirPath", null);
+        Deencapsulation.setField(job, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(job, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+
+        job.cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
+
+        Assert.assertFalse(localJobDir.exists());
+    }
+
+    @Test
+    public void testCleanupLocalSnapshotJobDirOnlyAfterExpired() throws IOException {
+        BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        File localJobDir = createLocalJobDir("local_snapshot_cleanup");
+        File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-09-11-00-00");
+        Assert.assertTrue(metaInfo.createNewFile());
+        Assert.assertTrue(jobInfo.createNewFile());
+
+        long createTime = System.currentTimeMillis();
+        Deencapsulation.setField(localSnapshotJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(localSnapshotJob, "createTime", createTime);
+        Deencapsulation.setField(localSnapshotJob, "localJobDirPath", null);
+        Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+
+        localSnapshotJob.cleanupLocalJobDirIfNecessary(createTime + 999);
+        Assert.assertTrue(localJobDir.exists());
+
+        localSnapshotJob.cleanupLocalJobDirIfNecessary(createTime + 1000);
+        Assert.assertFalse(localJobDir.exists());
+    }
+
+    @Test
+    public void testLocalSnapshotDataRemainsReadableAfterJobDirCleanup() throws IOException {
+        BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        File localJobDir = createLocalJobDir("local_snapshot_read_cleanup");
+        File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-09-12-00-00");
+        byte[] metaBytes = new byte[] {1, 2, 3};
+        byte[] jobInfoBytes = new byte[] {4, 5, 6};
+        Files.write(metaInfo.toPath(), metaBytes);
+        Files.write(jobInfo.toPath(), jobInfoBytes);
+
+        long createTime = System.currentTimeMillis();
+        Deencapsulation.setField(localSnapshotJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(localSnapshotJob, "createTime", createTime);
+        Deencapsulation.setField(localSnapshotJob, "localJobDirPath", null);
+        Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+
+        Snapshot snapshot = localSnapshotJob.getSnapshot();
+        localSnapshotJob.cleanupLocalJobDirAfterRemoved();
+
+        Assert.assertFalse(localJobDir.exists());
+        Assert.assertArrayEquals(metaBytes, snapshot.getMeta());
+        Assert.assertArrayEquals(jobInfoBytes, snapshot.getJobInfo());
+    }
+
+    @Test
+    public void testCleanupCancelledLocalSnapshotJobDirFromPersistedFilePaths() throws IOException {
+        BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        File localJobDir = createLocalJobDir("local_cancel_cleanup");
+        File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-09-13-00-00");
+        Assert.assertTrue(metaInfo.createNewFile());
+        Assert.assertTrue(jobInfo.createNewFile());
+
+        Deencapsulation.setField(localSnapshotJob, "state", BackupJobState.CANCELLED);
+        Deencapsulation.setField(localSnapshotJob, "localJobDirPath", null);
+        Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+
+        localSnapshotJob.cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
+
+        Assert.assertFalse(localJobDir.exists());
     }
 
     /**
@@ -649,5 +743,11 @@ public class BackupJobTest {
         // 3. delete files
         in.close();
         Files.delete(path);
+    }
+
+    private File createLocalJobDir(String name) throws IOException {
+        Path jobDirPath = BackupHandler.BACKUP_ROOT_DIR.resolve(name + "_" + id.getAndIncrement());
+        Files.createDirectories(jobDirPath);
+        return jobDirPath.toFile();
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -613,6 +613,41 @@ public class BackupJobTest {
     }
 
     @Test
+    public void testCleanupRetriesAfterDeleteFailure() throws IOException {
+        boolean[] failDelete = {true};
+        BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0) {
+            @Override
+            void deleteLocalJobDir(Path jobDirPath) throws IOException {
+                if (failDelete[0]) {
+                    failDelete[0] = false;
+                    throw new IOException("injected delete failure");
+                }
+                super.deleteLocalJobDir(jobDirPath);
+            }
+        };
+        File localJobDir = createLocalJobDir("local_snapshot_delete_retry");
+        File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-10-10-00-00");
+        Assert.assertTrue(metaInfo.createNewFile());
+        Assert.assertTrue(jobInfo.createNewFile());
+
+        Deencapsulation.setField(localSnapshotJob, "state", BackupJobState.CANCELLED);
+        Deencapsulation.setField(localSnapshotJob, "localJobDirPath", null);
+        Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+
+        localSnapshotJob.cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
+        Assert.assertTrue(localJobDir.exists());
+        Assert.assertFalse(Deencapsulation.getField(localSnapshotJob, "localJobDirCleaned"));
+
+        localSnapshotJob.cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
+        Assert.assertFalse(localJobDir.exists());
+        Assert.assertTrue(Deencapsulation.getField(localSnapshotJob, "localJobDirCleaned"));
+    }
+
+    @Test
     public void testLocalSnapshotIoFailurePropagatesAsIOException() throws IOException {
         BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
                 Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,


### PR DESCRIPTION
### 这个 PR 解决了什么问题？

Issue Number: none

Related PR: none

Problem Summary:

FE backup job 在以下场景中会遗留 `{tmp_dir}/backup/` 下的本地临时目录：

1. 远端 backup job 完成后；
2. FE 重启后（`localJobDirPath` 未持久化）；
3. 本地 snapshot 过期或 job 被历史队列淘汰后。

这些目录中的 meta/jobInfo 文件会持续占用磁盘空间。

此外，checkpoint 构建 image 时会重放 `SAVE_META` 并重新写出本地 staging 文件；后续终态重放原先不会再次清理，导致已经正常清理的远端 job 目录被重新创建。本地 snapshot 在 checkpoint/image 恢复时已经过期也存在同类遗留问题。

本地 snapshot 通过 CCR `getSnapshot` 返回时，需要保证目录清理不会删除正在读取的文件，并避免在 job 对象锁内执行大文件读取、压缩或目录删除 IO。对于 Thrift 无法承载的超大响应，也需要在读取前检查大小，并对压缩输出设置明确的协议尺寸上限。

### 修改内容

#### 本地 job 目录生命周期

1. 远端 backup job 成功进入 `FINISHED` 后，在写入 EditLog 之后立即清理本地目录。
2. 取消 job 时统一执行目录清理；当 FE 重启后 `localJobDirPath` 不存在时，可通过已持久化的 `localMetaInfoFilePath` / `localJobInfoFilePath` 恢复目录位置。
3. `BackupHandler` daemon 周期性清理已经结束的历史 job。
4. job 被每个 DB 的历史队列淘汰时清理本地目录。
5. 本地 snapshot 在取消、超时或历史队列淘汰后清理；其实际存活期同时受 `timeoutMs` 和 `max_backup_restore_job_num_per_db` 约束。
6. 清理路径必须位于 `BACKUP_ROOT_DIR` 下，目录遍历不跟随符号链接。
7. 删除失败时不标记为已清理，保留持久化路径，后续 daemon 周期可以重试。
8. 删除成功后清空持久化的本地目录、meta 和 jobInfo 路径，防止后续 image 再次携带已清理路径。

#### checkpoint、journal 与 image replay

1. checkpoint 线程重放 `SAVE_META` 时只重建内存状态，不再向 serving FE 共用的临时目录写 staging 文件。
2. journal 重放终态 job 后立即执行既有清理策略：远端终态 job 清理；本地 snapshot 仅在取消、过期或被淘汰时清理。
3. image 加载完成后统一执行一次同样的清理策略，覆盖只从 image 恢复、没有后续 journal 终态记录的情况。
4. 未过期的本地 snapshot 保留 staging 文件，仍可通过 `getSnapshot` 获取。

#### `getSnapshot` 与清理并发控制

1. `getSnapshot` 在 job 对象锁内完成状态检查、文件路径快照和 reader pin，消除检查完成到获取 reader pin 之间的竞态窗口。
2. 文件读取和压缩在释放 job 对象锁后执行，避免长时间阻塞同一 job 的 `run()`。
3. 目录清理只在 job 对象锁内判断是否需要执行，实际 walk/delete IO 在锁外进行。
4. `getSnapshot` reader 使用独立的 `localJobDirLock` 引用计数；存在 reader 时延迟清理，由最后一个 reader 释放时完成删除。
5. 文件读取或压缩异常继续作为 IO 异常返回，不会误报为 `SNAPSHOT_NOT_EXIST`。

#### 本地 snapshot 响应大小处理

1. 将 `enableCompress` 传入 `BackupHandler` / `BackupJob.getSnapshot`。
2. 使用 `Files.size()` 读取原始 meta/jobInfo 大小。
3. 未压缩响应总大小达到 `Integer.MAX_VALUE`（约 2GB）时，只返回文件大小，不读取内容，由 RPC 返回已有的 “Please enable compression” 错误。
4. 压缩响应从文件流式读取，不再先把完整原始文件加载到内存。
5. 压缩输出通过 `BoundedSizeOutputStream` 限制，总大小不能达到 Thrift 约 2GB 的消息边界；超出时抛出 IO 异常。
6. `Snapshot` 保存原始文件大小、最终响应字节和压缩标记，使目录在 materialization 完成后即可安全删除。

### 范围说明

本 PR 中的 2GB 限制用于避免超过 Thrift 消息边界，并将原先无上限的压缩输出改为有界输出；它不是根据 FE 当前 heap 使用量计算的内存安全阈值。

对于非常大且压缩率较低的 snapshot，`ByteArrayOutputStream` 扩容、`toByteArray()` 复制以及 Thrift 序列化仍可能产生较高的瞬时内存占用。基于 FE heap 的保守响应上限、临时文件 materialization 或响应协议改造属于独立的内存治理问题，不在本 PR 的本地目录生命周期与并发清理修复范围内。

### branch-3.1 适配说明

- 本 PR 将 master 开发分支上的本地目录生命周期与 `getSnapshot` 修复适配到 `branch-3.1`。
- 3.1 单测使用 `BackupStmt.BackupContent`，不使用 master 分支的 `BackupCommand` / `TableRefInfo` 接口。

### Release note

None（FE 内部本地临时目录清理及本地 snapshot RPC materialization 改进；除未压缩 snapshot 达到约 2GB 时沿用已有错误外，没有用户可见的 SQL/API 变化。）

### Check List（For Author）

- Test：
    - Unit Test：`./run-fe-ut.sh --run org.apache.doris.backup.BackupJobTest`，通过（20 tests）
    - 覆盖内容：
        - 从持久化文件路径恢复并清理远端 job 目录
        - 本地 snapshot 超时、取消和历史淘汰清理
        - checkpoint 重放 `SAVE_META` 不重新落盘
        - journal 重放 remote / 过期 local / 未过期 local 的终态清理策略
        - image 加载清理已完成的远端 job 目录
        - snapshot payload 在目录删除后仍可读取
        - FINISHED 路径清理目录
        - 未压缩超大 snapshot 在读取前进行尺寸检查（稀疏文件）
        - 压缩路径流式读取及内容正确性
        - reader pin 存在时延迟清理
        - 删除失败后重试并保留路径，成功后清空路径
- Behavior changed: Yes
    - FE 会在完成、超时、取消或历史淘汰后清理本地 backup job 临时目录。
    - checkpoint replay 不再重新创建已经清理的 staging 目录；journal/image 恢复会按 job 生命周期补做清理。
    - 本地 `getSnapshot` 不再在 job 对象锁内执行文件读取、压缩和目录删除 IO。
    - 未压缩超大 snapshot 不会在约 2GB Thrift 尺寸检查前读取完整文件。
- Does this need documentation: No
