### PR TITLE
[fix](backup) Centralize backup staging directory cleanup

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1599,6 +1599,13 @@ public class Config extends ConfigBase {
     public static int max_backup_restore_job_num_per_db = 10;
 
     /**
+     * Keep an unreferenced backup staging directory for this many seconds before deleting it.
+     * Orphan cleanup is disabled when this value is not positive.
+     */
+    @ConfField(mutable = true, masterOnly = false)
+    public static int backup_orphan_dir_keep_max_second = 2 * 24 * 3600;
+
+    /**
      * A internal config, to reduce backup/restore job json serialization memory by streaming.
      */
     @ConfField(mutable = true, masterOnly = false, description = {

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1606,6 +1606,13 @@ public class Config extends ConfigBase {
     public static int backup_orphan_dir_keep_max_second = 2 * 24 * 3600;
 
     /**
+     * Scan for orphan backup staging directories at this interval in seconds.
+     * Orphan cleanup is disabled when this value is not positive.
+     */
+    @ConfField(mutable = true, masterOnly = false)
+    public static long backup_orphan_dir_cleanup_interval_second = 3600;
+
+    /**
      * A internal config, to reduce backup/restore job json serialization memory by streaming.
      */
     @ConfField(mutable = true, masterOnly = false, description = {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -666,23 +666,29 @@ public class BackupHandler extends MasterDaemon implements Writable {
         }
 
         boolean checkpointThread = Env.isCheckpointThread();
-        if (job.isFinished() && job instanceof BackupJob) {
-            // A local snapshot is FE-local. Only expose it on a serving FE that has both files.
-            // The checkpoint handler only needs an in-memory copy to produce the image.
-            BackupJob backupJob = (BackupJob) job;
-            if (backupJob.isLocalSnapshot()
-                    && (checkpointThread || backupJob.hasLocalSnapshotFiles())) {
-                addSnapshot(backupJob.getLabel(), backupJob);
-            } else if (backupJob.isLocalSnapshot() && !checkpointThread) {
-                LOG.warn("skip unavailable local snapshot {} on this FE", backupJob.getLabel());
-            }
+        if (checkpointThread) {
+            // localSnapshots is runtime-only and is not written to the image. The checkpoint
+            // handler must not inspect, register, or clean serving-FE local snapshot files.
+            return;
         }
         for (BackupJob removedBackupJob : removedBackupJobs) {
             if (removedBackupJob.isLocalSnapshot()) {
-                removeSnapshot(removedBackupJob.getLabel());
+                removeSnapshot(removedBackupJob.getLabel(), removedBackupJob);
             }
-            if (!checkpointThread) {
-                removedBackupJob.cleanupLocalJobDirAfterRemoved();
+            removedBackupJob.cleanupLocalJobDirAfterRemoved();
+        }
+        if (job.isFinished() && job instanceof BackupJob) {
+            // A local snapshot is FE-local. Only expose it on a serving FE that has both files.
+            BackupJob backupJob = (BackupJob) job;
+            if (backupJob.isLocalSnapshot()) {
+                // The latest terminal job for a label supersedes any older local snapshot,
+                // even when its files are unavailable on this FE.
+                removeSnapshot(backupJob.getLabel());
+                if (backupJob.hasLocalSnapshotFiles()) {
+                    addSnapshot(backupJob.getLabel(), backupJob);
+                } else {
+                    LOG.warn("skip unavailable local snapshot {} on this FE", backupJob.getLabel());
+                }
             }
         }
     }
@@ -985,6 +991,18 @@ public class BackupHandler extends MasterDaemon implements Writable {
         localSnapshotsLock.writeLock().lock();
         try {
             localSnapshots.remove(labelName);
+        } finally {
+            localSnapshotsLock.writeLock().unlock();
+        }
+    }
+
+    private void removeSnapshot(String labelName, BackupJob backupJob) {
+        localSnapshotsLock.writeLock().lock();
+        try {
+            if (localSnapshots.get(labelName) == backupJob) {
+                LOG.info("remove snapshot {} from local repo", labelName);
+                localSnapshots.remove(labelName);
+            }
         } finally {
             localSnapshotsLock.writeLock().unlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -73,6 +73,8 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Deque;
@@ -87,6 +89,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class BackupHandler extends MasterDaemon implements Writable {
     private static final Logger LOG = LogManager.getLogger(BackupHandler.class);
@@ -104,6 +107,9 @@ public class BackupHandler extends MasterDaemon implements Writable {
     // If the last job is finished, user can get the job info from repository. If the last job is cancelled,
     // user can get the error message before submitting the next one.
     private final Map<Long, Deque<AbstractJob>> dbIdToBackupOrRestoreJobs = new HashMap<>();
+    // Evicted terminal jobs remain here until their staging directories are cleaned.
+    // Protected by jobLock and not persisted.
+    private final Deque<BackupJob> pendingCleanupJobs = new LinkedList<>();
 
     // this lock is used for handling one backup or restore request at a time.
     private ReentrantLock seqlock = new ReentrantLock();
@@ -112,10 +118,10 @@ public class BackupHandler extends MasterDaemon implements Writable {
 
     private Env env;
 
-    // map to store backup info, first key is db id and second key is label name
+    // map to store backup info, key is label name, value is the BackupJob
     // this map not present in persist && only in fe memory
-    // one database only keeps the latest snapshot for each label
-    private final Map<Long, Map<String, BackupJob>> localSnapshots = new HashMap<>();
+    // one table only keep one snapshot info, only keep last
+    private final Map<String, BackupJob> localSnapshots = new HashMap<>();
     private ReadWriteLock localSnapshotsLock = new ReentrantReadWriteLock();
 
     public BackupHandler() {
@@ -203,7 +209,10 @@ public class BackupHandler extends MasterDaemon implements Writable {
             job.setEnv(env);
             job.run();
         }
-        cleanupBackupJobLocalJobDirs();
+        long nowMs = System.currentTimeMillis();
+        cleanupBackupJobLocalJobDirs(nowMs);
+        cleanupPendingBackupJobLocalJobDirs();
+        cleanupOrphanBackupJobLocalJobDirs(nowMs);
     }
 
     // handle create repository stmt
@@ -661,35 +670,28 @@ public class BackupHandler extends MasterDaemon implements Writable {
                 jobs.removeLast();
             }
             jobs.addLast(job);
+
+            if (!Env.isCheckpointThread()) {
+                for (BackupJob removedBackupJob : removedBackupJobs) {
+                    if (removedBackupJob.isDone()) {
+                        pendingCleanupJobs.addLast(removedBackupJob);
+                    }
+                }
+            }
         } finally {
             jobLock.unlock();
         }
 
-        boolean checkpointThread = Env.isCheckpointThread();
-        if (checkpointThread) {
-            // localSnapshots is runtime-only and is not written to the image. The checkpoint
-            // handler must not inspect, register, or clean serving-FE local snapshot files.
-            return;
+        if (job.isFinished() && job instanceof BackupJob) {
+            // Save snapshot to local repo, when reload backupHandler from image.
+            BackupJob backupJob = (BackupJob) job;
+            if (backupJob.isLocalSnapshot()) {
+                addSnapshot(backupJob.getLabel(), backupJob);
+            }
         }
         for (BackupJob removedBackupJob : removedBackupJobs) {
             if (removedBackupJob.isLocalSnapshot()) {
-                removeSnapshot(removedBackupJob);
-            }
-            removedBackupJob.cleanupLocalJobDirAfterRemoved();
-        }
-        if (job.isFinished() && job instanceof BackupJob) {
-            // A local snapshot is FE-local. Only expose it on a serving FE that has both files.
-            BackupJob backupJob = (BackupJob) job;
-            if (backupJob.isLocalSnapshot()) {
-                // The latest terminal job for a label supersedes any older local snapshot,
-                // even when its files are unavailable on this FE.
-                removeSnapshot(backupJob.getDbId(), backupJob.getLabel());
-                if (backupJob.hasLocalSnapshotFiles()) {
-                    addSnapshot(backupJob);
-                } else {
-                    LOG.warn("skip unavailable local snapshot {} in db {} on this FE",
-                            backupJob.getLabel(), backupJob.getDbId());
-                }
+                removeSnapshot(removedBackupJob.getLabel());
             }
         }
     }
@@ -713,12 +715,118 @@ public class BackupHandler extends MasterDaemon implements Writable {
         }
     }
 
-    private void cleanupBackupJobLocalJobDirs() {
-        long nowMs = System.currentTimeMillis();
+    private void cleanupBackupJobLocalJobDirs(long nowMs) {
         for (AbstractJob job : getAllJobs()) {
             if (job instanceof BackupJob) {
                 ((BackupJob) job).cleanupLocalJobDirIfNecessary(nowMs);
             }
+        }
+    }
+
+    private void cleanupPendingBackupJobLocalJobDirs() {
+        List<BackupJob> pendingJobs;
+        jobLock.lock();
+        try {
+            pendingJobs = Lists.newArrayList(pendingCleanupJobs);
+        } finally {
+            jobLock.unlock();
+        }
+
+        for (BackupJob pendingJob : pendingJobs) {
+            if (pendingJob.cleanupLocalJobDirAfterRemoved()) {
+                jobLock.lock();
+                try {
+                    pendingCleanupJobs.removeFirstOccurrence(pendingJob);
+                } finally {
+                    jobLock.unlock();
+                }
+            }
+        }
+    }
+
+    private void cleanupOrphanBackupJobLocalJobDirs(long nowMs) {
+        Path backupRootDir = BACKUP_ROOT_DIR.toAbsolutePath().normalize();
+        if (!Files.isDirectory(backupRootDir, LinkOption.NOFOLLOW_LINKS)) {
+            return;
+        }
+        if (Config.backup_orphan_dir_keep_max_second <= 0) {
+            LOG.warn("skip orphan backup staging directory cleanup because "
+                    + "backup_orphan_dir_keep_max_second is not positive: {}",
+                    Config.backup_orphan_dir_keep_max_second);
+            return;
+        }
+
+        Set<Path> referencedJobDirs = getReferencedBackupJobDirs(backupRootDir);
+        long orphanExpireBeforeMs = nowMs
+                - TimeUnit.SECONDS.toMillis(Config.backup_orphan_dir_keep_max_second);
+        try {
+            for (Path repoDir : listChildDirectories(backupRootDir)) {
+                if (!repoDir.getFileName().toString().startsWith("repo__")) {
+                    continue;
+                }
+                cleanupOrphanJobDirsInRepo(repoDir, referencedJobDirs, orphanExpireBeforeMs);
+            }
+        } catch (IOException e) {
+            LOG.warn("failed to scan backup root dir for orphan staging directories: {}", backupRootDir, e);
+        }
+    }
+
+    private Set<Path> getReferencedBackupJobDirs(Path backupRootDir) {
+        List<BackupJob> backupJobs = Lists.newArrayList();
+        jobLock.lock();
+        try {
+            for (Deque<AbstractJob> jobs : dbIdToBackupOrRestoreJobs.values()) {
+                for (AbstractJob job : jobs) {
+                    if (job instanceof BackupJob) {
+                        backupJobs.add((BackupJob) job);
+                    }
+                }
+            }
+            backupJobs.addAll(pendingCleanupJobs);
+        } finally {
+            jobLock.unlock();
+        }
+
+        Set<Path> referencedJobDirs = Sets.newHashSet();
+        for (BackupJob backupJob : backupJobs) {
+            Path jobDir = backupJob.getLocalJobDirPath();
+            if (jobDir != null && jobDir.startsWith(backupRootDir) && !jobDir.equals(backupRootDir)) {
+                referencedJobDirs.add(jobDir);
+            }
+        }
+        return referencedJobDirs;
+    }
+
+    private void cleanupOrphanJobDirsInRepo(Path repoDir, Set<Path> referencedJobDirs,
+                                            long orphanExpireBeforeMs) {
+        List<Path> jobDirs;
+        try {
+            jobDirs = listChildDirectories(repoDir);
+        } catch (IOException e) {
+            LOG.warn("failed to scan backup repo dir for orphan staging directories: {}", repoDir, e);
+            return;
+        }
+
+        for (Path jobDir : jobDirs) {
+            try {
+                Path normalizedJobDir = jobDir.toAbsolutePath().normalize();
+                if (referencedJobDirs.contains(normalizedJobDir)
+                        || Files.getLastModifiedTime(normalizedJobDir, LinkOption.NOFOLLOW_LINKS).toMillis()
+                                > orphanExpireBeforeMs) {
+                    continue;
+                }
+                BackupJob.deleteLocalJobDirRecursively(normalizedJobDir);
+                LOG.info("cleaned orphan backup job dir: {}", normalizedJobDir);
+            } catch (IOException e) {
+                LOG.warn("failed to clean orphan backup job dir: {}", jobDir, e);
+            }
+        }
+    }
+
+    private List<Path> listChildDirectories(Path parentDir) throws IOException {
+        try (Stream<Path> paths = Files.list(parentDir)) {
+            return paths.filter(path -> Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS))
+                    .collect(Collectors.toList());
         }
     }
 
@@ -923,12 +1031,6 @@ public class BackupHandler extends MasterDaemon implements Writable {
     public void replayAddJob(AbstractJob job) {
         LOG.info("replay backup/restore job: {}", job);
 
-        boolean checkpointThread = Env.isCheckpointThread();
-        if (job instanceof BackupJob && !checkpointThread) {
-            // Journal paths may have been produced by another FE.
-            ((BackupJob) job).rebindLocalJobDirToCurrentFe();
-        }
-
         if (job.isCancelled()) {
             AbstractJob existingJob = getCurrentJob(job.getDbId());
             if (existingJob == null || existingJob.isDone()) {
@@ -953,9 +1055,6 @@ public class BackupHandler extends MasterDaemon implements Writable {
         }
 
         addBackupOrRestoreJob(job.getDbId(), job);
-        if (job instanceof BackupJob && !checkpointThread) {
-            ((BackupJob) job).cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
-        }
     }
 
     public boolean report(TTaskType type, long jobId, long taskId, int finishedNum, int totalNum) {
@@ -975,60 +1074,33 @@ public class BackupHandler extends MasterDaemon implements Writable {
         return false;
     }
 
-    public void addSnapshot(BackupJob backupJob) {
+    public void addSnapshot(String labelName, BackupJob backupJob) {
         assert backupJob.isFinished();
 
-        long dbId = backupJob.getDbId();
-        String labelName = backupJob.getLabel();
-        LOG.info("add snapshot {} in db {} to local repo", labelName, dbId);
+        LOG.info("add snapshot {} to local repo", labelName);
         localSnapshotsLock.writeLock().lock();
         try {
-            localSnapshots.computeIfAbsent(dbId, id -> new HashMap<>()).put(labelName, backupJob);
+            localSnapshots.put(labelName, backupJob);
         } finally {
             localSnapshotsLock.writeLock().unlock();
         }
     }
 
-    public void removeSnapshot(long dbId, String labelName) {
-        LOG.info("remove snapshot {} in db {} from local repo", labelName, dbId);
+    public void removeSnapshot(String labelName) {
+        LOG.info("remove snapshot {} from local repo", labelName);
         localSnapshotsLock.writeLock().lock();
         try {
-            Map<String, BackupJob> dbSnapshots = localSnapshots.get(dbId);
-            if (dbSnapshots != null) {
-                dbSnapshots.remove(labelName);
-                if (dbSnapshots.isEmpty()) {
-                    localSnapshots.remove(dbId);
-                }
-            }
+            localSnapshots.remove(labelName);
         } finally {
             localSnapshotsLock.writeLock().unlock();
         }
     }
 
-    private void removeSnapshot(BackupJob backupJob) {
-        long dbId = backupJob.getDbId();
-        String labelName = backupJob.getLabel();
-        localSnapshotsLock.writeLock().lock();
-        try {
-            Map<String, BackupJob> dbSnapshots = localSnapshots.get(dbId);
-            if (dbSnapshots != null && dbSnapshots.get(labelName) == backupJob) {
-                LOG.info("remove snapshot {} in db {} from local repo", labelName, dbId);
-                dbSnapshots.remove(labelName);
-                if (dbSnapshots.isEmpty()) {
-                    localSnapshots.remove(dbId);
-                }
-            }
-        } finally {
-            localSnapshotsLock.writeLock().unlock();
-        }
-    }
-
-    public Snapshot getSnapshot(long dbId, String labelName, boolean enableCompress) throws IOException {
+    public Snapshot getSnapshot(String labelName, boolean enableCompress) throws IOException {
         BackupJob backupJob;
         localSnapshotsLock.readLock().lock();
         try {
-            Map<String, BackupJob> dbSnapshots = localSnapshots.get(dbId);
-            backupJob = dbSnapshots == null ? null : dbSnapshots.get(labelName);
+            backupJob = localSnapshots.get(labelName);
         } finally {
             localSnapshotsLock.readLock().unlock();
         }
@@ -1061,18 +1133,10 @@ public class BackupHandler extends MasterDaemon implements Writable {
     public void readFields(DataInput in) throws IOException {
         repoMgr = RepositoryMgr.read(in);
 
-        boolean checkpointThread = Env.isCheckpointThread();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
             AbstractJob job = AbstractJob.read(in);
-            if (job instanceof BackupJob && !checkpointThread) {
-                // Image paths may have been produced by another FE.
-                ((BackupJob) job).rebindLocalJobDirToCurrentFe();
-            }
             addBackupOrRestoreJob(job.getDbId(), job);
-        }
-        if (!checkpointThread) {
-            cleanupBackupJobLocalJobDirs();
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -112,10 +112,10 @@ public class BackupHandler extends MasterDaemon implements Writable {
 
     private Env env;
 
-    // map to store backup info, key is label name, value is the BackupJob
+    // map to store backup info, first key is db id and second key is label name
     // this map not present in persist && only in fe memory
-    // one table only keep one snapshot info, only keep last
-    private final Map<String, BackupJob> localSnapshots = new HashMap<>();
+    // one database only keeps the latest snapshot for each label
+    private final Map<Long, Map<String, BackupJob>> localSnapshots = new HashMap<>();
     private ReadWriteLock localSnapshotsLock = new ReentrantReadWriteLock();
 
     public BackupHandler() {
@@ -673,7 +673,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
         }
         for (BackupJob removedBackupJob : removedBackupJobs) {
             if (removedBackupJob.isLocalSnapshot()) {
-                removeSnapshot(removedBackupJob.getLabel(), removedBackupJob);
+                removeSnapshot(removedBackupJob);
             }
             removedBackupJob.cleanupLocalJobDirAfterRemoved();
         }
@@ -683,11 +683,12 @@ public class BackupHandler extends MasterDaemon implements Writable {
             if (backupJob.isLocalSnapshot()) {
                 // The latest terminal job for a label supersedes any older local snapshot,
                 // even when its files are unavailable on this FE.
-                removeSnapshot(backupJob.getLabel());
+                removeSnapshot(backupJob.getDbId(), backupJob.getLabel());
                 if (backupJob.hasLocalSnapshotFiles()) {
-                    addSnapshot(backupJob.getLabel(), backupJob);
+                    addSnapshot(backupJob);
                 } else {
-                    LOG.warn("skip unavailable local snapshot {} on this FE", backupJob.getLabel());
+                    LOG.warn("skip unavailable local snapshot {} in db {} on this FE",
+                            backupJob.getLabel(), backupJob.getDbId());
                 }
             }
         }
@@ -974,45 +975,60 @@ public class BackupHandler extends MasterDaemon implements Writable {
         return false;
     }
 
-    public void addSnapshot(String labelName, BackupJob backupJob) {
+    public void addSnapshot(BackupJob backupJob) {
         assert backupJob.isFinished();
 
-        LOG.info("add snapshot {} to local repo", labelName);
+        long dbId = backupJob.getDbId();
+        String labelName = backupJob.getLabel();
+        LOG.info("add snapshot {} in db {} to local repo", labelName, dbId);
         localSnapshotsLock.writeLock().lock();
         try {
-            localSnapshots.put(labelName, backupJob);
+            localSnapshots.computeIfAbsent(dbId, id -> new HashMap<>()).put(labelName, backupJob);
         } finally {
             localSnapshotsLock.writeLock().unlock();
         }
     }
 
-    public void removeSnapshot(String labelName) {
-        LOG.info("remove snapshot {} from local repo", labelName);
+    public void removeSnapshot(long dbId, String labelName) {
+        LOG.info("remove snapshot {} in db {} from local repo", labelName, dbId);
         localSnapshotsLock.writeLock().lock();
         try {
-            localSnapshots.remove(labelName);
-        } finally {
-            localSnapshotsLock.writeLock().unlock();
-        }
-    }
-
-    private void removeSnapshot(String labelName, BackupJob backupJob) {
-        localSnapshotsLock.writeLock().lock();
-        try {
-            if (localSnapshots.get(labelName) == backupJob) {
-                LOG.info("remove snapshot {} from local repo", labelName);
-                localSnapshots.remove(labelName);
+            Map<String, BackupJob> dbSnapshots = localSnapshots.get(dbId);
+            if (dbSnapshots != null) {
+                dbSnapshots.remove(labelName);
+                if (dbSnapshots.isEmpty()) {
+                    localSnapshots.remove(dbId);
+                }
             }
         } finally {
             localSnapshotsLock.writeLock().unlock();
         }
     }
 
-    public Snapshot getSnapshot(String labelName, boolean enableCompress) throws IOException {
+    private void removeSnapshot(BackupJob backupJob) {
+        long dbId = backupJob.getDbId();
+        String labelName = backupJob.getLabel();
+        localSnapshotsLock.writeLock().lock();
+        try {
+            Map<String, BackupJob> dbSnapshots = localSnapshots.get(dbId);
+            if (dbSnapshots != null && dbSnapshots.get(labelName) == backupJob) {
+                LOG.info("remove snapshot {} in db {} from local repo", labelName, dbId);
+                dbSnapshots.remove(labelName);
+                if (dbSnapshots.isEmpty()) {
+                    localSnapshots.remove(dbId);
+                }
+            }
+        } finally {
+            localSnapshotsLock.writeLock().unlock();
+        }
+    }
+
+    public Snapshot getSnapshot(long dbId, String labelName, boolean enableCompress) throws IOException {
         BackupJob backupJob;
         localSnapshotsLock.readLock().lock();
         try {
-            backupJob = localSnapshots.get(labelName);
+            Map<String, BackupJob> dbSnapshots = localSnapshots.get(dbId);
+            backupJob = dbSnapshots == null ? null : dbSnapshots.get(labelName);
         } finally {
             localSnapshotsLock.readLock().unlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -665,18 +665,25 @@ public class BackupHandler extends MasterDaemon implements Writable {
             jobLock.unlock();
         }
 
+        boolean checkpointThread = Env.isCheckpointThread();
         if (job.isFinished() && job instanceof BackupJob) {
-            // Save snapshot to local repo, when reload backupHandler from image.
+            // A local snapshot is FE-local. Only expose it on a serving FE that has both files.
+            // The checkpoint handler only needs an in-memory copy to produce the image.
             BackupJob backupJob = (BackupJob) job;
-            if (backupJob.isLocalSnapshot()) {
+            if (backupJob.isLocalSnapshot()
+                    && (checkpointThread || backupJob.hasLocalSnapshotFiles())) {
                 addSnapshot(backupJob.getLabel(), backupJob);
+            } else if (backupJob.isLocalSnapshot() && !checkpointThread) {
+                LOG.warn("skip unavailable local snapshot {} on this FE", backupJob.getLabel());
             }
         }
         for (BackupJob removedBackupJob : removedBackupJobs) {
             if (removedBackupJob.isLocalSnapshot()) {
                 removeSnapshot(removedBackupJob.getLabel());
             }
-            removedBackupJob.cleanupLocalJobDirAfterRemoved();
+            if (!checkpointThread) {
+                removedBackupJob.cleanupLocalJobDirAfterRemoved();
+            }
         }
     }
 
@@ -909,6 +916,12 @@ public class BackupHandler extends MasterDaemon implements Writable {
     public void replayAddJob(AbstractJob job) {
         LOG.info("replay backup/restore job: {}", job);
 
+        boolean checkpointThread = Env.isCheckpointThread();
+        if (job instanceof BackupJob && !checkpointThread) {
+            // Journal paths may have been produced by another FE.
+            ((BackupJob) job).rebindLocalJobDirToCurrentFe();
+        }
+
         if (job.isCancelled()) {
             AbstractJob existingJob = getCurrentJob(job.getDbId());
             if (existingJob == null || existingJob.isDone()) {
@@ -933,7 +946,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
         }
 
         addBackupOrRestoreJob(job.getDbId(), job);
-        if (job instanceof BackupJob) {
+        if (job instanceof BackupJob && !checkpointThread) {
             ((BackupJob) job).cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
         }
     }
@@ -1014,11 +1027,18 @@ public class BackupHandler extends MasterDaemon implements Writable {
     public void readFields(DataInput in) throws IOException {
         repoMgr = RepositoryMgr.read(in);
 
+        boolean checkpointThread = Env.isCheckpointThread();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
             AbstractJob job = AbstractJob.read(in);
+            if (job instanceof BackupJob && !checkpointThread) {
+                // Image paths may have been produced by another FE.
+                ((BackupJob) job).rebindLocalJobDirToCurrentFe();
+            }
             addBackupOrRestoreJob(job.getDbId(), job);
         }
-        cleanupBackupJobLocalJobDirs();
+        if (!checkpointThread) {
+            cleanupBackupJobLocalJobDirs();
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -933,6 +933,9 @@ public class BackupHandler extends MasterDaemon implements Writable {
         }
 
         addBackupOrRestoreJob(job.getDbId(), job);
+        if (job instanceof BackupJob) {
+            ((BackupJob) job).cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
+        }
     }
 
     public boolean report(TTaskType type, long jobId, long taskId, int finishedNum, int totalNum) {
@@ -1016,5 +1019,6 @@ public class BackupHandler extends MasterDaemon implements Writable {
             AbstractJob job = AbstractJob.read(in);
             addBackupOrRestoreJob(job.getDbId(), job);
         }
+        cleanupBackupJobLocalJobDirs();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -110,6 +110,8 @@ public class BackupHandler extends MasterDaemon implements Writable {
     // Evicted terminal jobs remain here until their staging directories are cleaned.
     // Protected by jobLock and not persisted.
     private final Deque<BackupJob> pendingCleanupJobs = new LinkedList<>();
+    // Accessed only by the backup handler daemon thread.
+    private long lastOrphanJobDirCleanupTimeMs = 0;
 
     // this lock is used for handling one backup or restore request at a time.
     private ReentrantLock seqlock = new ReentrantLock();
@@ -210,9 +212,12 @@ public class BackupHandler extends MasterDaemon implements Writable {
             job.run();
         }
         long nowMs = System.currentTimeMillis();
-        cleanupBackupJobLocalJobDirs(nowMs);
-        cleanupPendingBackupJobLocalJobDirs();
-        cleanupOrphanBackupJobLocalJobDirs(nowMs);
+        long cleanupStartNanos = System.nanoTime();
+        CleanupStats currentJobStats = cleanupBackupJobLocalJobDirs(nowMs);
+        CleanupStats pendingJobStats = cleanupPendingBackupJobLocalJobDirs();
+        CleanupStats orphanStats = cleanupOrphanBackupJobLocalJobDirsIfNecessary(nowMs);
+        long cleanupElapsedMs = elapsedMillis(cleanupStartNanos);
+        logCleanupStats(currentJobStats, pendingJobStats, orphanStats, cleanupElapsedMs);
     }
 
     // handle create repository stmt
@@ -715,15 +720,29 @@ public class BackupHandler extends MasterDaemon implements Writable {
         }
     }
 
-    private void cleanupBackupJobLocalJobDirs(long nowMs) {
+    private CleanupStats cleanupBackupJobLocalJobDirs(long nowMs) {
+        long startNanos = System.nanoTime();
+        CleanupStats stats = new CleanupStats(true);
         for (AbstractJob job : getAllJobs()) {
             if (job instanceof BackupJob) {
-                ((BackupJob) job).cleanupLocalJobDirIfNecessary(nowMs);
+                stats.itemsScanned++;
+                BackupJob backupJob = (BackupJob) job;
+                Path jobDirBeforeCleanup = backupJob.getLocalJobDirPath();
+                boolean cleanupCompleted = backupJob.cleanupLocalJobDirIfNecessary(nowMs);
+                if (jobDirBeforeCleanup != null && backupJob.getLocalJobDirPath() == null) {
+                    stats.directoriesCleaned++;
+                } else if (!cleanupCompleted) {
+                    stats.deferredOrFailed++;
+                }
             }
         }
+        stats.elapsedMs = elapsedMillis(startNanos);
+        return stats;
     }
 
-    private void cleanupPendingBackupJobLocalJobDirs() {
+    private CleanupStats cleanupPendingBackupJobLocalJobDirs() {
+        long startNanos = System.nanoTime();
+        CleanupStats stats = new CleanupStats(true);
         List<BackupJob> pendingJobs;
         jobLock.lock();
         try {
@@ -733,27 +752,61 @@ public class BackupHandler extends MasterDaemon implements Writable {
         }
 
         for (BackupJob pendingJob : pendingJobs) {
+            stats.itemsScanned++;
+            Path jobDirBeforeCleanup = pendingJob.getLocalJobDirPath();
             if (pendingJob.cleanupLocalJobDirAfterRemoved()) {
+                if (jobDirBeforeCleanup != null && pendingJob.getLocalJobDirPath() == null) {
+                    stats.directoriesCleaned++;
+                }
                 jobLock.lock();
                 try {
                     pendingCleanupJobs.removeFirstOccurrence(pendingJob);
                 } finally {
                     jobLock.unlock();
                 }
+            } else {
+                stats.deferredOrFailed++;
             }
         }
+        jobLock.lock();
+        try {
+            stats.remainingItems = pendingCleanupJobs.size();
+        } finally {
+            jobLock.unlock();
+        }
+        stats.elapsedMs = elapsedMillis(startNanos);
+        return stats;
     }
 
-    private void cleanupOrphanBackupJobLocalJobDirs(long nowMs) {
+    private CleanupStats cleanupOrphanBackupJobLocalJobDirsIfNecessary(long nowMs) {
+        long cleanupIntervalSecond = Config.backup_orphan_dir_cleanup_interval_second;
+        if (cleanupIntervalSecond <= 0) {
+            return CleanupStats.notRun();
+        }
+        long cleanupIntervalMs = TimeUnit.SECONDS.toMillis(cleanupIntervalSecond);
+        if (lastOrphanJobDirCleanupTimeMs != 0
+                && nowMs >= lastOrphanJobDirCleanupTimeMs
+                && nowMs - lastOrphanJobDirCleanupTimeMs < cleanupIntervalMs) {
+            return CleanupStats.notRun();
+        }
+        lastOrphanJobDirCleanupTimeMs = nowMs;
+        return cleanupOrphanBackupJobLocalJobDirs(nowMs);
+    }
+
+    private CleanupStats cleanupOrphanBackupJobLocalJobDirs(long nowMs) {
+        long startNanos = System.nanoTime();
+        CleanupStats stats = new CleanupStats(true);
         Path backupRootDir = BACKUP_ROOT_DIR.toAbsolutePath().normalize();
         if (!Files.isDirectory(backupRootDir, LinkOption.NOFOLLOW_LINKS)) {
-            return;
+            stats.elapsedMs = elapsedMillis(startNanos);
+            return stats;
         }
         if (Config.backup_orphan_dir_keep_max_second <= 0) {
             LOG.warn("skip orphan backup staging directory cleanup because "
                     + "backup_orphan_dir_keep_max_second is not positive: {}",
                     Config.backup_orphan_dir_keep_max_second);
-            return;
+            stats.elapsedMs = elapsedMillis(startNanos);
+            return stats;
         }
 
         Set<Path> referencedJobDirs = getReferencedBackupJobDirs(backupRootDir);
@@ -764,11 +817,15 @@ public class BackupHandler extends MasterDaemon implements Writable {
                 if (!repoDir.getFileName().toString().startsWith("repo__")) {
                     continue;
                 }
-                cleanupOrphanJobDirsInRepo(repoDir, referencedJobDirs, orphanExpireBeforeMs);
+                stats.containersScanned++;
+                cleanupOrphanJobDirsInRepo(repoDir, referencedJobDirs, orphanExpireBeforeMs, stats);
             }
         } catch (IOException e) {
+            stats.failures++;
             LOG.warn("failed to scan backup root dir for orphan staging directories: {}", backupRootDir, e);
         }
+        stats.elapsedMs = elapsedMillis(startNanos);
+        return stats;
     }
 
     private Set<Path> getReferencedBackupJobDirs(Path backupRootDir) {
@@ -798,16 +855,19 @@ public class BackupHandler extends MasterDaemon implements Writable {
     }
 
     private void cleanupOrphanJobDirsInRepo(Path repoDir, Set<Path> referencedJobDirs,
-                                            long orphanExpireBeforeMs) {
+                                            long orphanExpireBeforeMs, CleanupStats stats) {
         List<Path> jobDirs;
         try {
             jobDirs = listChildDirectories(repoDir);
         } catch (IOException e) {
+            stats.failures++;
             LOG.warn("failed to scan backup repo dir for orphan staging directories: {}", repoDir, e);
             return;
         }
 
         for (Path jobDir : jobDirs) {
+            stats.itemsScanned++;
+            long cleanupStartNanos = System.nanoTime();
             try {
                 Path normalizedJobDir = jobDir.toAbsolutePath().normalize();
                 if (referencedJobDirs.contains(normalizedJobDir)
@@ -816,10 +876,63 @@ public class BackupHandler extends MasterDaemon implements Writable {
                     continue;
                 }
                 BackupJob.deleteLocalJobDirRecursively(normalizedJobDir);
-                LOG.info("cleaned orphan backup job dir: {}", normalizedJobDir);
+                stats.directoriesCleaned++;
+                LOG.info("cleaned orphan backup job dir: {}, elapsed_ms={}", normalizedJobDir,
+                        elapsedMillis(cleanupStartNanos));
             } catch (IOException e) {
-                LOG.warn("failed to clean orphan backup job dir: {}", jobDir, e);
+                stats.failures++;
+                LOG.warn("failed to clean orphan backup job dir: {}, elapsed_ms={}", jobDir,
+                        elapsedMillis(cleanupStartNanos), e);
             }
+        }
+    }
+
+    private void logCleanupStats(CleanupStats currentJobStats, CleanupStats pendingJobStats,
+                                 CleanupStats orphanStats, long totalElapsedMs) {
+        String message = "backup staging cleanup cycle finished: current_jobs_scanned={}, "
+                + "current_dirs_cleaned={}, current_deferred_or_failed={}, current_elapsed_ms={}, "
+                + "pending_jobs_scanned={}, pending_dirs_cleaned={}, pending_deferred_or_failed={}, "
+                + "pending_jobs_remaining={}, pending_elapsed_ms={}, orphan_ran={}, "
+                + "orphan_repo_dirs_scanned={}, orphan_job_dirs_scanned={}, orphan_dirs_cleaned={}, "
+                + "orphan_failures={}, orphan_elapsed_ms={}, total_elapsed_ms={}, daemon_interval_ms={}";
+        Object[] params = new Object[] {
+                currentJobStats.itemsScanned, currentJobStats.directoriesCleaned,
+                currentJobStats.deferredOrFailed, currentJobStats.elapsedMs,
+                pendingJobStats.itemsScanned, pendingJobStats.directoriesCleaned,
+                pendingJobStats.deferredOrFailed, pendingJobStats.remainingItems, pendingJobStats.elapsedMs,
+                orphanStats.ran, orphanStats.containersScanned, orphanStats.itemsScanned,
+                orphanStats.directoriesCleaned, orphanStats.failures, orphanStats.elapsedMs, totalElapsedMs,
+                Config.backup_handler_update_interval_millis
+        };
+        if (totalElapsedMs >= Config.backup_handler_update_interval_millis) {
+            LOG.warn(message, params);
+        } else if (currentJobStats.directoriesCleaned > 0 || pendingJobStats.itemsScanned > 0 || orphanStats.ran) {
+            LOG.info(message, params);
+        } else {
+            LOG.debug(message, params);
+        }
+    }
+
+    private static long elapsedMillis(long startNanos) {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+    }
+
+    private static class CleanupStats {
+        private final boolean ran;
+        private int containersScanned;
+        private int itemsScanned;
+        private int directoriesCleaned;
+        private int deferredOrFailed;
+        private int failures;
+        private int remainingItems;
+        private long elapsedMs;
+
+        private CleanupStats(boolean ran) {
+            this.ran = ran;
+        }
+
+        private static CleanupStats notRun() {
+            return new CleanupStats(false);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -213,7 +213,7 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     Path buildLocalJobDirPath() {
         return BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize()
                 .resolve("repo__" + repoId)
-                .resolve("job__" + jobId + "__" + createTime)
+                .resolve(label + "__" + getCreateTimeString())
                 .normalize();
     }
 
@@ -241,23 +241,23 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         if (!Repository.FILE_META_INFO.equals(metaInfoPath.getFileName().toString())) {
             return false;
         }
-        if (jobDirPath.equals(buildLocalJobDirPath())) {
-            return getLocalJobInfoFileName().equals(jobInfoPath.getFileName().toString());
-        }
-
-        Path legacyRepoDir = BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize().resolve("repo__" + repoId);
-        String legacyDirPrefix = label + "__";
-        String legacyDirName = jobDirPath.getFileName().toString();
-        if (!legacyRepoDir.equals(jobDirPath.getParent()) || !legacyDirName.startsWith(legacyDirPrefix)) {
+        Path repoDir = BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize().resolve("repo__" + repoId);
+        String dirPrefix = label + "__";
+        String dirName = jobDirPath.getFileName().toString();
+        if (!repoDir.equals(jobDirPath.getParent()) || !dirName.startsWith(dirPrefix)) {
             return false;
         }
-        String legacyCreateTime = legacyDirName.substring(legacyDirPrefix.length());
-        return !legacyCreateTime.isEmpty()
-                && (Repository.PREFIX_JOB_INFO + legacyCreateTime).equals(jobInfoPath.getFileName().toString());
+        String createTimeString = dirName.substring(dirPrefix.length());
+        return !createTimeString.isEmpty()
+                && (Repository.PREFIX_JOB_INFO + createTimeString).equals(jobInfoPath.getFileName().toString());
     }
 
     private String getLocalJobInfoFileName() {
-        return Repository.PREFIX_JOB_INFO + createTime;
+        return Repository.PREFIX_JOB_INFO + getCreateTimeString();
+    }
+
+    private String getCreateTimeString() {
+        return TimeUtils.longToTimeString(createTime, TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
     }
 
     boolean hasLocalSnapshotFiles() {
@@ -1022,8 +1022,7 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     }
 
     private void saveMetaInfo(boolean replay) {
-        // The directory and file names use stable numeric job identity so replay and
-        // image loading cannot change them when the global time zone changes.
+        // Keep the legacy staging layout so older FEs can replay jobs during rolling upgrades.
         rebindLocalJobDirToCurrentFe();
 
         try {
@@ -1159,7 +1158,7 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         LOG.info("job is finished. {}", this);
 
         if (repoId == Repository.KEEP_ON_LOCAL_REPO_ID) {
-            env.getBackupHandler().addSnapshot(label, this);
+            env.getBackupHandler().addSnapshot(this);
             return;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -1256,10 +1256,15 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         }
     }
 
+    /**
+     * Remote staging files have no value after the terminal state is durable, while a
+     * local snapshot must remain available until its configured expiration time.
+     */
     void cleanupLocalJobDirIfNecessary(long nowMs) {
         boolean shouldCleanup;
         synchronized (this) {
-            shouldCleanup = isDone() && nowMs >= createTime + timeoutMs;
+            shouldCleanup = isDone() && (repoId != Repository.KEEP_ON_LOCAL_REPO_ID
+                    || nowMs >= createTime + timeoutMs);
         }
         if (shouldCleanup) {
             cleanupLocalJobDir();

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -80,6 +80,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
@@ -138,7 +139,6 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
      */
     private final Object localJobDirLock = new Object();
     private int localJobDirReaders = 0;
-    private boolean localJobDirCleanupPending = false;
     private boolean localJobDirCleaned = false;
     // backup properties && table commit seq with table id
     @SerializedName("prop")
@@ -1257,18 +1257,19 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     }
 
     /**
-     * Remote staging files have no value after the terminal state is durable, while a
-     * local snapshot must remain available until its configured expiration time.
+     * Cancelled and remote finished jobs have no staging value, while a local finished
+     * snapshot must remain available until its configured expiration time.
      */
-    void cleanupLocalJobDirIfNecessary(long nowMs) {
+    boolean cleanupLocalJobDirIfNecessary(long nowMs) {
         boolean shouldCleanup;
         synchronized (this) {
-            shouldCleanup = isDone() && (repoId != Repository.KEEP_ON_LOCAL_REPO_ID
-                    || nowMs >= createTime + timeoutMs);
+            shouldCleanup = isCancelled() || (isFinished() && (repoId != Repository.KEEP_ON_LOCAL_REPO_ID
+                    || nowMs >= createTime + timeoutMs));
         }
         if (shouldCleanup) {
-            cleanupLocalJobDir();
+            return cleanupLocalJobDir();
         }
+        return true;
     }
 
     /**
@@ -1289,8 +1290,9 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
 
     /**
      * Delete local staging dir when no getSnapshot reader is active; otherwise defer
-     * until the last reader releases. Deletion uses {@link #localJobDirLock} only and
-     * never runs while holding the job monitor.
+     * until a later backup handler cleanup cycle after the last reader releases.
+     * Deletion uses {@link #localJobDirLock} only and never runs while holding the job
+     * monitor or on the getSnapshot RPC thread.
      */
     private boolean cleanupLocalJobDir() {
         synchronized (localJobDirLock) {
@@ -1298,7 +1300,6 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
                 return true;
             }
             if (localJobDirReaders > 0) {
-                localJobDirCleanupPending = true;
                 return false;
             }
             return cleanupLocalJobDirUnderLock();
@@ -1321,15 +1322,11 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     private void releaseLocalJobDirRead() {
         synchronized (localJobDirLock) {
             localJobDirReaders--;
-            if (localJobDirReaders == 0 && localJobDirCleanupPending) {
-                cleanupLocalJobDirUnderLock();
-            }
         }
     }
 
     /** Caller must hold {@link #localJobDirLock}. */
     private boolean cleanupLocalJobDirUnderLock() {
-        localJobDirCleanupPending = false;
         Path jobDirPath = getLocalJobDirPathForCleanup();
         if (jobDirPath == null) {
             localJobDirCleaned = true;
@@ -1341,11 +1338,13 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             localJobDirCleaned = true;
             return true;
         }
+        long cleanupStartNanos = System.nanoTime();
         try {
             File jobDir = normalizedJobDirPath.toFile();
             if (jobDir.exists()) {
                 deleteLocalJobDir(normalizedJobDirPath);
-                LOG.info("cleaned backup job dir: {}. {}", normalizedJobDirPath, this);
+                LOG.info("cleaned backup job dir: {}, elapsed_ms={}. {}", normalizedJobDirPath,
+                        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - cleanupStartNanos), this);
             }
             localJobDirPath = null;
             localMetaInfoFilePath = null;
@@ -1353,7 +1352,8 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             localJobDirCleaned = true;
             return true;
         } catch (Exception e) {
-            LOG.warn("failed to clean the backup job dir: {}. {}", normalizedJobDirPath, this, e);
+            LOG.warn("failed to clean the backup job dir: {}, elapsed_ms={}. {}", normalizedJobDirPath,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - cleanupStartNanos), this, e);
             return false;
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -199,20 +199,65 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
      * Persisted paths may belong to another FE, while all local file IO must use this FE's tmp dir.
      */
     void rebindLocalJobDirToCurrentFe() {
-        Path jobDirPath = buildLocalJobDirPath();
-        String createTimeStr = getCreateTimeString();
         synchronized (localJobDirLock) {
+            if (useExistingLocalJobDirIfPresent()) {
+                return;
+            }
+            Path jobDirPath = buildLocalJobDirPath();
             localJobDirPath = jobDirPath;
             localMetaInfoFilePath = jobDirPath.resolve(Repository.FILE_META_INFO).toString();
-            localJobInfoFilePath = jobDirPath.resolve(Repository.PREFIX_JOB_INFO + createTimeStr).toString();
+            localJobInfoFilePath = jobDirPath.resolve(getLocalJobInfoFileName()).toString();
         }
     }
 
     Path buildLocalJobDirPath() {
         return BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize()
                 .resolve("repo__" + repoId)
-                .resolve(label + "__" + getCreateTimeString())
+                .resolve("job__" + jobId + "__" + createTime)
                 .normalize();
+    }
+
+    /** Caller must hold {@link #localJobDirLock}. */
+    private boolean useExistingLocalJobDirIfPresent() {
+        if (localMetaInfoFilePath == null || localJobInfoFilePath == null) {
+            return false;
+        }
+        Path metaInfoPath = Paths.get(localMetaInfoFilePath).toAbsolutePath().normalize();
+        Path jobInfoPath = Paths.get(localJobInfoFilePath).toAbsolutePath().normalize();
+        Path jobDirPath = metaInfoPath.getParent();
+        if (jobDirPath == null || !jobDirPath.equals(jobInfoPath.getParent())
+                || !isValidLocalJobDirForCleanup(jobDirPath)
+                || !isExpectedLocalJobDir(metaInfoPath, jobInfoPath, jobDirPath)
+                || !Files.isDirectory(jobDirPath, LinkOption.NOFOLLOW_LINKS)) {
+            return false;
+        }
+        localJobDirPath = jobDirPath;
+        localMetaInfoFilePath = metaInfoPath.toString();
+        localJobInfoFilePath = jobInfoPath.toString();
+        return true;
+    }
+
+    private boolean isExpectedLocalJobDir(Path metaInfoPath, Path jobInfoPath, Path jobDirPath) {
+        if (!Repository.FILE_META_INFO.equals(metaInfoPath.getFileName().toString())) {
+            return false;
+        }
+        if (jobDirPath.equals(buildLocalJobDirPath())) {
+            return getLocalJobInfoFileName().equals(jobInfoPath.getFileName().toString());
+        }
+
+        Path legacyRepoDir = BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize().resolve("repo__" + repoId);
+        String legacyDirPrefix = label + "__";
+        String legacyDirName = jobDirPath.getFileName().toString();
+        if (!legacyRepoDir.equals(jobDirPath.getParent()) || !legacyDirName.startsWith(legacyDirPrefix)) {
+            return false;
+        }
+        String legacyCreateTime = legacyDirName.substring(legacyDirPrefix.length());
+        return !legacyCreateTime.isEmpty()
+                && (Repository.PREFIX_JOB_INFO + legacyCreateTime).equals(jobInfoPath.getFileName().toString());
+    }
+
+    private String getLocalJobInfoFileName() {
+        return Repository.PREFIX_JOB_INFO + createTime;
     }
 
     boolean hasLocalSnapshotFiles() {
@@ -231,10 +276,6 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
                 && isValidLocalJobDirForCleanup(jobDirPath)
                 && Files.isRegularFile(metaInfoPath, LinkOption.NOFOLLOW_LINKS)
                 && Files.isRegularFile(jobInfoPath, LinkOption.NOFOLLOW_LINKS);
-    }
-
-    private String getCreateTimeString() {
-        return TimeUtils.longToTimeString(createTime, TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
     }
 
     public BackupContent getContent() {
@@ -981,9 +1022,8 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     }
 
     private void saveMetaInfo(boolean replay) {
-        String createTimeStr = getCreateTimeString();
-        // local job dir: backup/repo__repo_id/label__createtime/
-        // Add repo_id to isolate jobs from different repos.
+        // The directory and file names use stable numeric job identity so replay and
+        // image loading cannot change them when the global time zone changes.
         rebindLocalJobDirToCurrentFe();
 
         try {
@@ -1043,7 +1083,7 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("job info: {}. {}", jobInfo, this);
             }
-            File jobInfoFile = new File(jobDir, Repository.PREFIX_JOB_INFO + createTimeStr);
+            File jobInfoFile = new File(jobDir, getLocalJobInfoFileName());
             if (!jobInfoFile.createNewFile()) {
                 status = new Status(ErrCode.COMMON_ERROR, "Failed to create job info file: " + jobInfoFile.toString());
                 return;

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -72,7 +72,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -192,90 +191,6 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
 
     public String getLocalMetaInfoFilePath() {
         return localMetaInfoFilePath;
-    }
-
-    /**
-     * Rebind host-local staging paths after loading a job from cluster-wide journal or image data.
-     * Persisted paths may belong to another FE, while all local file IO must use this FE's tmp dir.
-     */
-    void rebindLocalJobDirToCurrentFe() {
-        synchronized (localJobDirLock) {
-            if (useExistingLocalJobDirIfPresent()) {
-                return;
-            }
-            Path jobDirPath = buildLocalJobDirPath();
-            localJobDirPath = jobDirPath;
-            localMetaInfoFilePath = jobDirPath.resolve(Repository.FILE_META_INFO).toString();
-            localJobInfoFilePath = jobDirPath.resolve(getLocalJobInfoFileName()).toString();
-        }
-    }
-
-    Path buildLocalJobDirPath() {
-        return BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize()
-                .resolve("repo__" + repoId)
-                .resolve(label + "__" + getCreateTimeString())
-                .normalize();
-    }
-
-    /** Caller must hold {@link #localJobDirLock}. */
-    private boolean useExistingLocalJobDirIfPresent() {
-        if (localMetaInfoFilePath == null || localJobInfoFilePath == null) {
-            return false;
-        }
-        Path metaInfoPath = Paths.get(localMetaInfoFilePath).toAbsolutePath().normalize();
-        Path jobInfoPath = Paths.get(localJobInfoFilePath).toAbsolutePath().normalize();
-        Path jobDirPath = metaInfoPath.getParent();
-        if (jobDirPath == null || !jobDirPath.equals(jobInfoPath.getParent())
-                || !isValidLocalJobDirForCleanup(jobDirPath)
-                || !isExpectedLocalJobDir(metaInfoPath, jobInfoPath, jobDirPath)
-                || !Files.isDirectory(jobDirPath, LinkOption.NOFOLLOW_LINKS)) {
-            return false;
-        }
-        localJobDirPath = jobDirPath;
-        localMetaInfoFilePath = metaInfoPath.toString();
-        localJobInfoFilePath = jobInfoPath.toString();
-        return true;
-    }
-
-    private boolean isExpectedLocalJobDir(Path metaInfoPath, Path jobInfoPath, Path jobDirPath) {
-        if (!Repository.FILE_META_INFO.equals(metaInfoPath.getFileName().toString())) {
-            return false;
-        }
-        Path repoDir = BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize().resolve("repo__" + repoId);
-        String dirPrefix = label + "__";
-        String dirName = jobDirPath.getFileName().toString();
-        if (!repoDir.equals(jobDirPath.getParent()) || !dirName.startsWith(dirPrefix)) {
-            return false;
-        }
-        String createTimeString = dirName.substring(dirPrefix.length());
-        return !createTimeString.isEmpty()
-                && (Repository.PREFIX_JOB_INFO + createTimeString).equals(jobInfoPath.getFileName().toString());
-    }
-
-    private String getLocalJobInfoFileName() {
-        return Repository.PREFIX_JOB_INFO + getCreateTimeString();
-    }
-
-    private String getCreateTimeString() {
-        return TimeUtils.longToTimeString(createTime, TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
-    }
-
-    boolean hasLocalSnapshotFiles() {
-        Path metaInfoPath;
-        Path jobInfoPath;
-        synchronized (localJobDirLock) {
-            if (localMetaInfoFilePath == null || localJobInfoFilePath == null) {
-                return false;
-            }
-            metaInfoPath = Paths.get(localMetaInfoFilePath).toAbsolutePath().normalize();
-            jobInfoPath = Paths.get(localJobInfoFilePath).toAbsolutePath().normalize();
-        }
-        Path jobDirPath = metaInfoPath.getParent();
-        return jobDirPath != null
-                && jobDirPath.equals(jobInfoPath.getParent())
-                && isValidLocalJobDirForCleanup(jobDirPath)
-                && Files.isRegularFile(metaInfoPath, LinkOption.NOFOLLOW_LINKS)
-                && Files.isRegularFile(jobInfoPath, LinkOption.NOFOLLOW_LINKS);
     }
 
     public BackupContent getContent() {
@@ -497,8 +412,8 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
 
     @Override
     public synchronized void replayRun() {
-        // Checkpoint replay only reconstructs in-memory state for the image. Materializing
-        // files there would recreate already-cleaned dirs in the serving FE's shared tmp dir.
+        // Checkpoint replay only reconstructs state for the image. Writing staging files
+        // here recreates directories that were already cleaned by the serving FE.
         if (state == BackupJobState.SAVE_META && !Env.isCheckpointThread()) {
             saveMetaInfo(true);
         }
@@ -1022,8 +937,12 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     }
 
     private void saveMetaInfo(boolean replay) {
-        // Keep the legacy staging layout so older FEs can replay jobs during rolling upgrades.
-        rebindLocalJobDirToCurrentFe();
+        String createTimeStr = TimeUtils.longToTimeString(createTime,
+                TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
+        // local job dir: backup/repo__repo_id/label__createtime/
+        // Add repo_id to isolate jobs from different repos.
+        localJobDirPath = Paths.get(BackupHandler.BACKUP_ROOT_DIR.toString(),
+                                    "repo__" + repoId, label + "__" + createTimeStr).normalize();
 
         try {
             // 1. create local job dir of this backup job
@@ -1082,7 +1001,7 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("job info: {}. {}", jobInfo, this);
             }
-            File jobInfoFile = new File(jobDir, getLocalJobInfoFileName());
+            File jobInfoFile = new File(jobDir, Repository.PREFIX_JOB_INFO + createTimeStr);
             if (!jobInfoFile.createNewFile()) {
                 status = new Status(ErrCode.COMMON_ERROR, "Failed to create job info file: " + jobInfoFile.toString());
                 return;
@@ -1158,11 +1077,9 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         LOG.info("job is finished. {}", this);
 
         if (repoId == Repository.KEEP_ON_LOCAL_REPO_ID) {
-            env.getBackupHandler().addSnapshot(this);
+            env.getBackupHandler().addSnapshot(label, this);
             return;
         }
-
-        cleanupLocalJobDir();
     }
 
     private boolean uploadFile(String localFilePath, String remoteFilePath) {
@@ -1224,8 +1141,6 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             default:
                 break;
         }
-
-        cleanupLocalJobDir();
 
         // meta info and job info not need save in log when cancel, we need to clean them here
         backupMeta = null;
@@ -1295,7 +1210,6 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         }
 
         if (expiredSnapshot != null) {
-            cleanupLocalJobDir();
             return expiredSnapshot;
         }
 
@@ -1345,11 +1259,7 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     void cleanupLocalJobDirIfNecessary(long nowMs) {
         boolean shouldCleanup;
         synchronized (this) {
-            if (repoId != Repository.KEEP_ON_LOCAL_REPO_ID) {
-                shouldCleanup = isDone();
-            } else {
-                shouldCleanup = isCancelled() || (isFinished() && nowMs >= createTime + timeoutMs);
-            }
+            shouldCleanup = isDone() && nowMs >= createTime + timeoutMs;
         }
         if (shouldCleanup) {
             cleanupLocalJobDir();
@@ -1361,32 +1271,32 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
      * Local snapshot lifetime is bounded by both {@link #timeoutMs} and
      * {@code max_backup_restore_job_num_per_db} queue eviction.
      */
-    void cleanupLocalJobDirAfterRemoved() {
+    boolean cleanupLocalJobDirAfterRemoved() {
         boolean shouldCleanup;
         synchronized (this) {
             shouldCleanup = isDone();
         }
         if (shouldCleanup) {
-            cleanupLocalJobDir();
+            return cleanupLocalJobDir();
         }
+        return true;
     }
 
     /**
      * Delete local staging dir when no getSnapshot reader is active; otherwise defer
-     * until the last reader releases. Must not run heavy IO while holding the job monitor
-     * for longer than the brief synchronized callers already do — deletion itself uses
-     * {@link #localJobDirLock} only.
+     * until the last reader releases. Deletion uses {@link #localJobDirLock} only and
+     * never runs while holding the job monitor.
      */
-    private void cleanupLocalJobDir() {
+    private boolean cleanupLocalJobDir() {
         synchronized (localJobDirLock) {
             if (localJobDirCleaned) {
-                return;
+                return true;
             }
             if (localJobDirReaders > 0) {
                 localJobDirCleanupPending = true;
-                return;
+                return false;
             }
-            cleanupLocalJobDirUnderLock();
+            return cleanupLocalJobDirUnderLock();
         }
     }
 
@@ -1413,17 +1323,18 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     }
 
     /** Caller must hold {@link #localJobDirLock}. */
-    private void cleanupLocalJobDirUnderLock() {
+    private boolean cleanupLocalJobDirUnderLock() {
         localJobDirCleanupPending = false;
         Path jobDirPath = getLocalJobDirPathForCleanup();
         if (jobDirPath == null) {
             localJobDirCleaned = true;
-            return;
+            return true;
         }
         Path normalizedJobDirPath = jobDirPath.toAbsolutePath().normalize();
         if (!isValidLocalJobDirForCleanup(normalizedJobDirPath)) {
             LOG.warn("skip cleaning invalid backup job dir: {}. {}", normalizedJobDirPath, this);
-            return;
+            localJobDirCleaned = true;
+            return true;
         }
         try {
             File jobDir = normalizedJobDirPath.toFile();
@@ -1435,12 +1346,25 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             localMetaInfoFilePath = null;
             localJobInfoFilePath = null;
             localJobDirCleaned = true;
+            return true;
         } catch (Exception e) {
             LOG.warn("failed to clean the backup job dir: {}. {}", normalizedJobDirPath, this, e);
+            return false;
+        }
+    }
+
+    Path getLocalJobDirPath() {
+        synchronized (localJobDirLock) {
+            Path jobDirPath = getLocalJobDirPathForCleanup();
+            return jobDirPath == null ? null : jobDirPath.toAbsolutePath().normalize();
         }
     }
 
     void deleteLocalJobDir(Path jobDirPath) throws IOException {
+        deleteLocalJobDirRecursively(jobDirPath);
+    }
+
+    static void deleteLocalJobDirRecursively(Path jobDirPath) throws IOException {
         try (Stream<Path> paths = Files.walk(jobDirPath)) {
             List<Path> pathsToDelete = paths.sorted(Comparator.reverseOrder()).collect(Collectors.toList());
             for (Path path : pathsToDelete) {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -412,7 +412,9 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
 
     @Override
     public synchronized void replayRun() {
-        if (state == BackupJobState.SAVE_META) {
+        // Checkpoint replay only reconstructs in-memory state for the image. Materializing
+        // files there would recreate already-cleaned dirs in the serving FE's shared tmp dir.
+        if (state == BackupJobState.SAVE_META && !Env.isCheckpointThread()) {
             saveMetaInfo(true);
         }
     }
@@ -1349,6 +1351,8 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
                 LOG.info("cleaned backup job dir: {}. {}", normalizedJobDirPath, this);
             }
             localJobDirPath = null;
+            localMetaInfoFilePath = null;
+            localJobInfoFilePath = null;
             localJobDirCleaned = true;
         } catch (Exception e) {
             LOG.warn("failed to clean the backup job dir: {}. {}", normalizedJobDirPath, this, e);

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -72,6 +72,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -191,6 +192,49 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
 
     public String getLocalMetaInfoFilePath() {
         return localMetaInfoFilePath;
+    }
+
+    /**
+     * Rebind host-local staging paths after loading a job from cluster-wide journal or image data.
+     * Persisted paths may belong to another FE, while all local file IO must use this FE's tmp dir.
+     */
+    void rebindLocalJobDirToCurrentFe() {
+        Path jobDirPath = buildLocalJobDirPath();
+        String createTimeStr = getCreateTimeString();
+        synchronized (localJobDirLock) {
+            localJobDirPath = jobDirPath;
+            localMetaInfoFilePath = jobDirPath.resolve(Repository.FILE_META_INFO).toString();
+            localJobInfoFilePath = jobDirPath.resolve(Repository.PREFIX_JOB_INFO + createTimeStr).toString();
+        }
+    }
+
+    Path buildLocalJobDirPath() {
+        return BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize()
+                .resolve("repo__" + repoId)
+                .resolve(label + "__" + getCreateTimeString())
+                .normalize();
+    }
+
+    boolean hasLocalSnapshotFiles() {
+        Path metaInfoPath;
+        Path jobInfoPath;
+        synchronized (localJobDirLock) {
+            if (localMetaInfoFilePath == null || localJobInfoFilePath == null) {
+                return false;
+            }
+            metaInfoPath = Paths.get(localMetaInfoFilePath).toAbsolutePath().normalize();
+            jobInfoPath = Paths.get(localJobInfoFilePath).toAbsolutePath().normalize();
+        }
+        Path jobDirPath = metaInfoPath.getParent();
+        return jobDirPath != null
+                && jobDirPath.equals(jobInfoPath.getParent())
+                && isValidLocalJobDirForCleanup(jobDirPath)
+                && Files.isRegularFile(metaInfoPath, LinkOption.NOFOLLOW_LINKS)
+                && Files.isRegularFile(jobInfoPath, LinkOption.NOFOLLOW_LINKS);
+    }
+
+    private String getCreateTimeString() {
+        return TimeUtils.longToTimeString(createTime, TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
     }
 
     public BackupContent getContent() {
@@ -937,12 +981,10 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     }
 
     private void saveMetaInfo(boolean replay) {
-        String createTimeStr = TimeUtils.longToTimeString(createTime,
-                TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
+        String createTimeStr = getCreateTimeString();
         // local job dir: backup/repo__repo_id/label__createtime/
         // Add repo_id to isolate jobs from different repos.
-        localJobDirPath = Paths.get(BackupHandler.BACKUP_ROOT_DIR.toString(),
-                                    "repo__" + repoId, label + "__" + createTimeStr).normalize();
+        rebindLocalJobDirToCurrentFe();
 
         try {
             // 1. create local job dir of this backup job

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -3131,12 +3131,13 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
         // Step 3: get snapshot
         String label = request.getLabelName();
+        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException(request.getDb());
         TGetSnapshotResult result = new TGetSnapshotResult();
         result.setStatus(new TStatus(TStatusCode.OK));
         boolean enableCompress = request.isEnableCompress();
         // Materialize (or size-check) with file refcount; IOException propagates as INTERNAL_ERROR.
         // Do not re-read files after return.
-        Snapshot snapshot = Env.getCurrentEnv().getBackupHandler().getSnapshot(label, enableCompress);
+        Snapshot snapshot = Env.getCurrentEnv().getBackupHandler().getSnapshot(db.getId(), label, enableCompress);
         if (snapshot == null) {
             result.getStatus().setStatusCode(TStatusCode.SNAPSHOT_NOT_EXIST);
             result.getStatus().addToErrorMsgs(String.format("snapshot %s not exist", label));

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -3131,13 +3131,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
         // Step 3: get snapshot
         String label = request.getLabelName();
-        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException(request.getDb());
         TGetSnapshotResult result = new TGetSnapshotResult();
         result.setStatus(new TStatus(TStatusCode.OK));
         boolean enableCompress = request.isEnableCompress();
         // Materialize (or size-check) with file refcount; IOException propagates as INTERNAL_ERROR.
         // Do not re-read files after return.
-        Snapshot snapshot = Env.getCurrentEnv().getBackupHandler().getSnapshot(db.getId(), label, enableCompress);
+        Snapshot snapshot = Env.getCurrentEnv().getBackupHandler().getSnapshot(label, enableCompress);
         if (snapshot == null) {
             result.getStatus().setStatusCode(TStatusCode.SNAPSHOT_NOT_EXIST);
             result.getStatus().addToErrorMsgs(String.format("snapshot %s not exist", label));

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -35,6 +35,7 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.GZIPUtils;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.UnitTestUtil;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
@@ -65,11 +66,14 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.lang.reflect.Field;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -641,10 +645,152 @@ public class BackupJobTest {
         localSnapshotJob.cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
         Assert.assertTrue(localJobDir.exists());
         Assert.assertFalse(Deencapsulation.getField(localSnapshotJob, "localJobDirCleaned"));
+        Assert.assertEquals(metaInfo.getAbsolutePath(), localSnapshotJob.getLocalMetaInfoFilePath());
+        Assert.assertEquals(jobInfo.getAbsolutePath(), localSnapshotJob.getLocalJobInfoFilePath());
 
         localSnapshotJob.cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
         Assert.assertFalse(localJobDir.exists());
         Assert.assertTrue(Deencapsulation.getField(localSnapshotJob, "localJobDirCleaned"));
+        Assert.assertNull(localSnapshotJob.getLocalMetaInfoFilePath());
+        Assert.assertNull(localSnapshotJob.getLocalJobInfoFilePath());
+    }
+
+    @Test
+    public void testCheckpointReplayDoesNotMaterializeLocalJobDir() throws Exception {
+        BackupJob replayJob = new BackupJob("checkpoint_replay", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, repoId, 0);
+        Deencapsulation.setField(replayJob, "state", BackupJobState.SAVE_META);
+
+        String createTimeStr = TimeUtils.longToTimeString(replayJob.getCreateTime(),
+                TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
+        Path jobDir = BackupHandler.BACKUP_ROOT_DIR.resolve("repo__" + repoId)
+                .resolve("checkpoint_replay__" + createTimeStr);
+        Files.createDirectories(jobDir);
+        Path marker = jobDir.resolve("checkpoint_marker");
+        Files.createFile(marker);
+
+        Field checkpointThreadIdField = Env.class.getDeclaredField("checkpointThreadId");
+        checkpointThreadIdField.setAccessible(true);
+        long checkpointThreadId = checkpointThreadIdField.getLong(null);
+        checkpointThreadIdField.setLong(null, Thread.currentThread().getId());
+        try {
+            replayJob.replayRun();
+        } finally {
+            checkpointThreadIdField.setLong(null, checkpointThreadId);
+        }
+
+        Assert.assertTrue("checkpoint replay must not replace serving FE staging files", Files.exists(marker));
+    }
+
+    @Test
+    public void testReplayTerminalJobCleanupPolicy() throws IOException {
+        BackupHandler remoteHandler = new BackupHandler(env);
+        BackupJob remotePendingJob = new BackupJob("remote_replay", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, repoId, 0);
+        remoteHandler.replayAddJob(remotePendingJob);
+
+        File remoteJobDir = createLocalJobDir("remote_replay_finished");
+        File remoteMetaInfo = new File(remoteJobDir, Repository.FILE_META_INFO);
+        File remoteJobInfo = new File(remoteJobDir, Repository.PREFIX_JOB_INFO + "2026-07-14-10-00-00");
+        Assert.assertTrue(remoteMetaInfo.createNewFile());
+        Assert.assertTrue(remoteJobInfo.createNewFile());
+        BackupJob remoteFinishedJob = new BackupJob("remote_replay", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, repoId, 0);
+        Deencapsulation.setField(remoteFinishedJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(remoteFinishedJob, "localMetaInfoFilePath", remoteMetaInfo.getAbsolutePath());
+        Deencapsulation.setField(remoteFinishedJob, "localJobInfoFilePath", remoteJobInfo.getAbsolutePath());
+
+        remoteHandler.replayAddJob(remoteFinishedJob);
+
+        Assert.assertFalse(remoteJobDir.exists());
+        Assert.assertNull(remoteFinishedJob.getLocalMetaInfoFilePath());
+        Assert.assertNull(remoteFinishedJob.getLocalJobInfoFilePath());
+
+        long localDbId = dbId + 1;
+        BackupHandler expiredLocalHandler = new BackupHandler(env);
+        BackupJob expiredLocalPendingJob = new BackupJob("expired_local_replay", localDbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 1, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        expiredLocalHandler.replayAddJob(expiredLocalPendingJob);
+
+        File expiredLocalJobDir = createLocalJobDir("expired_local_replay_finished");
+        File expiredLocalMetaInfo = new File(expiredLocalJobDir, Repository.FILE_META_INFO);
+        File expiredLocalJobInfo = new File(expiredLocalJobDir,
+                Repository.PREFIX_JOB_INFO + "2026-07-14-10-00-01");
+        Assert.assertTrue(expiredLocalMetaInfo.createNewFile());
+        Assert.assertTrue(expiredLocalJobInfo.createNewFile());
+        BackupJob expiredLocalFinishedJob = new BackupJob("expired_local_replay", localDbId,
+                UnitTestUtil.DB_NAME, Lists.newArrayList(), 1, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        Deencapsulation.setField(expiredLocalFinishedJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(expiredLocalFinishedJob, "createTime", System.currentTimeMillis() - 1000);
+        Deencapsulation.setField(expiredLocalFinishedJob, "localMetaInfoFilePath",
+                expiredLocalMetaInfo.getAbsolutePath());
+        Deencapsulation.setField(expiredLocalFinishedJob, "localJobInfoFilePath",
+                expiredLocalJobInfo.getAbsolutePath());
+
+        expiredLocalHandler.replayAddJob(expiredLocalFinishedJob);
+
+        Assert.assertFalse(expiredLocalJobDir.exists());
+
+        long unexpiredLocalDbId = dbId + 2;
+        BackupHandler unexpiredLocalHandler = new BackupHandler(env);
+        BackupJob unexpiredLocalPendingJob = new BackupJob("unexpired_local_replay", unexpiredLocalDbId,
+                UnitTestUtil.DB_NAME, Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        unexpiredLocalHandler.replayAddJob(unexpiredLocalPendingJob);
+
+        File unexpiredLocalJobDir = createLocalJobDir("unexpired_local_replay_finished");
+        File unexpiredLocalMetaInfo = new File(unexpiredLocalJobDir, Repository.FILE_META_INFO);
+        File unexpiredLocalJobInfo = new File(unexpiredLocalJobDir,
+                Repository.PREFIX_JOB_INFO + "2026-07-14-10-00-02");
+        Assert.assertTrue(unexpiredLocalMetaInfo.createNewFile());
+        Assert.assertTrue(unexpiredLocalJobInfo.createNewFile());
+        BackupJob unexpiredLocalFinishedJob = new BackupJob("unexpired_local_replay", unexpiredLocalDbId,
+                UnitTestUtil.DB_NAME, Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        Deencapsulation.setField(unexpiredLocalFinishedJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(unexpiredLocalFinishedJob, "localMetaInfoFilePath",
+                unexpiredLocalMetaInfo.getAbsolutePath());
+        Deencapsulation.setField(unexpiredLocalFinishedJob, "localJobInfoFilePath",
+                unexpiredLocalJobInfo.getAbsolutePath());
+
+        unexpiredLocalHandler.replayAddJob(unexpiredLocalFinishedJob);
+
+        Assert.assertTrue(unexpiredLocalJobDir.exists());
+    }
+
+    @Test
+    public void testImageLoadCleansFinishedRemoteJobDir() throws IOException {
+        BackupHandler serializedHandler = new BackupHandler(env);
+        File remoteJobDir = createLocalJobDir("image_remote_finished");
+        File metaInfo = new File(remoteJobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(remoteJobDir, Repository.PREFIX_JOB_INFO + "2026-07-14-11-00-00");
+        Assert.assertTrue(metaInfo.createNewFile());
+        Assert.assertTrue(jobInfo.createNewFile());
+
+        BackupJob remoteFinishedJob = new BackupJob("image_remote", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, repoId, 0);
+        Deencapsulation.setField(remoteFinishedJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(remoteFinishedJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(remoteFinishedJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+        Deencapsulation.invoke(serializedHandler, "addBackupOrRestoreJob", dbId, remoteFinishedJob);
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            serializedHandler.write(out);
+        }
+
+        BackupHandler loadedHandler = new BackupHandler();
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            loadedHandler.readFields(in);
+        }
+
+        Assert.assertFalse(remoteJobDir.exists());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -691,21 +691,23 @@ public class BackupJobTest {
                 env, repoId, 0);
         remoteHandler.replayAddJob(remotePendingJob);
 
-        File remoteJobDir = createLocalJobDir("remote_replay_finished");
-        File remoteMetaInfo = new File(remoteJobDir, Repository.FILE_META_INFO);
-        File remoteJobInfo = new File(remoteJobDir, Repository.PREFIX_JOB_INFO + "2026-07-14-10-00-00");
-        Assert.assertTrue(remoteMetaInfo.createNewFile());
-        Assert.assertTrue(remoteJobInfo.createNewFile());
         BackupJob remoteFinishedJob = new BackupJob("remote_replay", dbId, UnitTestUtil.DB_NAME,
                 Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
                 env, repoId, 0);
         Deencapsulation.setField(remoteFinishedJob, "state", BackupJobState.FINISHED);
-        Deencapsulation.setField(remoteFinishedJob, "localMetaInfoFilePath", remoteMetaInfo.getAbsolutePath());
-        Deencapsulation.setField(remoteFinishedJob, "localJobInfoFilePath", remoteJobInfo.getAbsolutePath());
+        File remoteJobDir = createLocalSnapshotFiles(remoteFinishedJob);
+        File foreignRemoteJobDir = createLocalJobDir("foreign_fe_remote_replay");
+        File foreignMetaInfo = new File(foreignRemoteJobDir, Repository.FILE_META_INFO);
+        File foreignJobInfo = new File(foreignRemoteJobDir, Repository.PREFIX_JOB_INFO + "foreign");
+        Assert.assertTrue(foreignMetaInfo.createNewFile());
+        Assert.assertTrue(foreignJobInfo.createNewFile());
+        Deencapsulation.setField(remoteFinishedJob, "localMetaInfoFilePath", foreignMetaInfo.getAbsolutePath());
+        Deencapsulation.setField(remoteFinishedJob, "localJobInfoFilePath", foreignJobInfo.getAbsolutePath());
 
         remoteHandler.replayAddJob(remoteFinishedJob);
 
         Assert.assertFalse(remoteJobDir.exists());
+        Assert.assertTrue("replay must not clean another FE's persisted path", foreignRemoteJobDir.exists());
         Assert.assertNull(remoteFinishedJob.getLocalMetaInfoFilePath());
         Assert.assertNull(remoteFinishedJob.getLocalJobInfoFilePath());
 
@@ -716,21 +718,13 @@ public class BackupJobTest {
                 env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
         expiredLocalHandler.replayAddJob(expiredLocalPendingJob);
 
-        File expiredLocalJobDir = createLocalJobDir("expired_local_replay_finished");
-        File expiredLocalMetaInfo = new File(expiredLocalJobDir, Repository.FILE_META_INFO);
-        File expiredLocalJobInfo = new File(expiredLocalJobDir,
-                Repository.PREFIX_JOB_INFO + "2026-07-14-10-00-01");
-        Assert.assertTrue(expiredLocalMetaInfo.createNewFile());
-        Assert.assertTrue(expiredLocalJobInfo.createNewFile());
         BackupJob expiredLocalFinishedJob = new BackupJob("expired_local_replay", localDbId,
                 UnitTestUtil.DB_NAME, Lists.newArrayList(), 1, BackupStmt.BackupContent.ALL,
                 env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
         Deencapsulation.setField(expiredLocalFinishedJob, "state", BackupJobState.FINISHED);
         Deencapsulation.setField(expiredLocalFinishedJob, "createTime", System.currentTimeMillis() - 1000);
-        Deencapsulation.setField(expiredLocalFinishedJob, "localMetaInfoFilePath",
-                expiredLocalMetaInfo.getAbsolutePath());
-        Deencapsulation.setField(expiredLocalFinishedJob, "localJobInfoFilePath",
-                expiredLocalJobInfo.getAbsolutePath());
+        File expiredLocalJobDir = createLocalSnapshotFiles(expiredLocalFinishedJob);
+        setForeignLocalSnapshotPaths(expiredLocalFinishedJob);
 
         expiredLocalHandler.replayAddJob(expiredLocalFinishedJob);
 
@@ -743,41 +737,28 @@ public class BackupJobTest {
                 env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
         unexpiredLocalHandler.replayAddJob(unexpiredLocalPendingJob);
 
-        File unexpiredLocalJobDir = createLocalJobDir("unexpired_local_replay_finished");
-        File unexpiredLocalMetaInfo = new File(unexpiredLocalJobDir, Repository.FILE_META_INFO);
-        File unexpiredLocalJobInfo = new File(unexpiredLocalJobDir,
-                Repository.PREFIX_JOB_INFO + "2026-07-14-10-00-02");
-        Assert.assertTrue(unexpiredLocalMetaInfo.createNewFile());
-        Assert.assertTrue(unexpiredLocalJobInfo.createNewFile());
         BackupJob unexpiredLocalFinishedJob = new BackupJob("unexpired_local_replay", unexpiredLocalDbId,
                 UnitTestUtil.DB_NAME, Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
                 env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
         Deencapsulation.setField(unexpiredLocalFinishedJob, "state", BackupJobState.FINISHED);
-        Deencapsulation.setField(unexpiredLocalFinishedJob, "localMetaInfoFilePath",
-                unexpiredLocalMetaInfo.getAbsolutePath());
-        Deencapsulation.setField(unexpiredLocalFinishedJob, "localJobInfoFilePath",
-                unexpiredLocalJobInfo.getAbsolutePath());
+        File unexpiredLocalJobDir = createLocalSnapshotFiles(unexpiredLocalFinishedJob);
+        setForeignLocalSnapshotPaths(unexpiredLocalFinishedJob);
 
         unexpiredLocalHandler.replayAddJob(unexpiredLocalFinishedJob);
 
         Assert.assertTrue(unexpiredLocalJobDir.exists());
+        Assert.assertNotNull(unexpiredLocalHandler.getSnapshot("unexpired_local_replay", false));
     }
 
     @Test
-    public void testImageLoadCleansFinishedRemoteJobDir() throws IOException {
+    public void testImageLoadRebindsAndCleansFinishedRemoteJobDir() throws IOException {
         BackupHandler serializedHandler = new BackupHandler(env);
-        File remoteJobDir = createLocalJobDir("image_remote_finished");
-        File metaInfo = new File(remoteJobDir, Repository.FILE_META_INFO);
-        File jobInfo = new File(remoteJobDir, Repository.PREFIX_JOB_INFO + "2026-07-14-11-00-00");
-        Assert.assertTrue(metaInfo.createNewFile());
-        Assert.assertTrue(jobInfo.createNewFile());
-
         BackupJob remoteFinishedJob = new BackupJob("image_remote", dbId, UnitTestUtil.DB_NAME,
                 Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
                 env, repoId, 0);
         Deencapsulation.setField(remoteFinishedJob, "state", BackupJobState.FINISHED);
-        Deencapsulation.setField(remoteFinishedJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
-        Deencapsulation.setField(remoteFinishedJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+        File remoteJobDir = createLocalSnapshotFiles(remoteFinishedJob);
+        setForeignLocalSnapshotPaths(remoteFinishedJob);
         Deencapsulation.invoke(serializedHandler, "addBackupOrRestoreJob", dbId, remoteFinishedJob);
 
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
@@ -791,6 +772,85 @@ public class BackupJobTest {
         }
 
         Assert.assertFalse(remoteJobDir.exists());
+    }
+
+    @Test
+    public void testImageLoadDoesNotRegisterUnavailableLocalSnapshot() throws IOException {
+        BackupHandler serializedHandler = new BackupHandler(env);
+        BackupJob localFinishedJob = new BackupJob("missing_local_image", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        Deencapsulation.setField(localFinishedJob, "state", BackupJobState.FINISHED);
+        setForeignLocalSnapshotPaths(localFinishedJob);
+        Deencapsulation.invoke(serializedHandler, "addBackupOrRestoreJob", dbId, localFinishedJob);
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            serializedHandler.write(out);
+        }
+
+        BackupHandler loadedHandler = new BackupHandler();
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            loadedHandler.readFields(in);
+        }
+
+        Assert.assertNull(loadedHandler.getSnapshot("missing_local_image", false));
+    }
+
+    @Test
+    public void testCheckpointHandlerDoesNotTouchServingFeLocalJobDir() throws Exception {
+        Field checkpointThreadIdField = Env.class.getDeclaredField("checkpointThreadId");
+        checkpointThreadIdField.setAccessible(true);
+        long checkpointThreadId = checkpointThreadIdField.getLong(null);
+        checkpointThreadIdField.setLong(null, Thread.currentThread().getId());
+        try {
+            File markerDir = createLocalJobDir("checkpoint_handler_marker");
+            File marker = new File(markerDir, "serving_fe_marker");
+            Assert.assertTrue(marker.createNewFile());
+
+            BackupHandler replayHandler = new BackupHandler(env);
+            BackupJob pendingJob = new BackupJob("checkpoint_handler", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                    env, repoId, 0);
+            replayHandler.replayAddJob(pendingJob);
+            BackupJob finishedJob = new BackupJob("checkpoint_handler", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                    env, repoId, 0);
+            Deencapsulation.setField(finishedJob, "state", BackupJobState.FINISHED);
+            Deencapsulation.setField(finishedJob, "localMetaInfoFilePath",
+                    new File(markerDir, Repository.FILE_META_INFO).getAbsolutePath());
+            Deencapsulation.setField(finishedJob, "localJobInfoFilePath",
+                    new File(markerDir, Repository.PREFIX_JOB_INFO + "checkpoint").getAbsolutePath());
+
+            replayHandler.replayAddJob(finishedJob);
+            Assert.assertTrue("checkpoint replay must not delete serving FE files", marker.exists());
+
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            try (DataOutputStream out = new DataOutputStream(bytes)) {
+                replayHandler.write(out);
+            }
+            BackupHandler loadedHandler = new BackupHandler();
+            try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+                loadedHandler.readFields(in);
+            }
+            Assert.assertTrue("checkpoint image load must not delete serving FE files", marker.exists());
+
+            int previousMaxJobNum = Config.max_backup_restore_job_num_per_db;
+            try {
+                Config.max_backup_restore_job_num_per_db = 1;
+                BackupHandler evictionHandler = new BackupHandler(env);
+                Deencapsulation.invoke(evictionHandler, "addBackupOrRestoreJob", dbId, finishedJob);
+                BackupJob replacementJob = new BackupJob("checkpoint_replacement", dbId, UnitTestUtil.DB_NAME,
+                        Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                        env, repoId, 0);
+                Deencapsulation.invoke(evictionHandler, "addBackupOrRestoreJob", dbId, replacementJob);
+                Assert.assertTrue("checkpoint queue eviction must not delete serving FE files", marker.exists());
+            } finally {
+                Config.max_backup_restore_job_num_per_db = previousMaxJobNum;
+            }
+        } finally {
+            checkpointThreadIdField.setLong(null, checkpointThreadId);
+        }
     }
 
     @Test
@@ -1124,6 +1184,22 @@ public class BackupJobTest {
         Path jobDirPath = BackupHandler.BACKUP_ROOT_DIR.resolve(name + "_" + id.getAndIncrement());
         Files.createDirectories(jobDirPath);
         return jobDirPath.toFile();
+    }
+
+    private File createLocalSnapshotFiles(BackupJob backupJob) throws IOException {
+        Path jobDirPath = backupJob.buildLocalJobDirPath();
+        Files.createDirectories(jobDirPath);
+        Assert.assertTrue(Files.createFile(jobDirPath.resolve(Repository.FILE_META_INFO)).toFile().exists());
+        String createTimeStr = TimeUtils.longToTimeString(backupJob.getCreateTime(),
+                TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
+        Assert.assertTrue(Files.createFile(jobDirPath.resolve(Repository.PREFIX_JOB_INFO + createTimeStr))
+                .toFile().exists());
+        return jobDirPath.toFile();
+    }
+
+    private void setForeignLocalSnapshotPaths(BackupJob backupJob) {
+        Deencapsulation.setField(backupJob, "localMetaInfoFilePath", "/foreign-fe/tmp/backup/__meta");
+        Deencapsulation.setField(backupJob, "localJobInfoFilePath", "/foreign-fe/tmp/backup/__job_info");
     }
 
     private void createSparseFile(File file, long logicalSize) throws IOException {

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -805,6 +805,7 @@ public class BackupJobTest {
         BackupJob previousJob = new BackupJob(label, dbId, UnitTestUtil.DB_NAME,
                 Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
                 env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        Deencapsulation.setField(previousJob, "jobId", 50001L);
         Deencapsulation.setField(previousJob, "state", BackupJobState.FINISHED);
         createLocalSnapshotFiles(previousJob);
         previousJob.rebindLocalJobDirToCurrentFe();
@@ -814,8 +815,11 @@ public class BackupJobTest {
         BackupJob latestJob = new BackupJob(label, dbId, UnitTestUtil.DB_NAME,
                 Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
                 env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        Deencapsulation.setField(latestJob, "jobId", 50002L);
         Deencapsulation.setField(latestJob, "state", BackupJobState.FINISHED);
         latestJob.rebindLocalJobDirToCurrentFe();
+        Assert.assertNotEquals(previousJob.buildLocalJobDirPath(), latestJob.buildLocalJobDirPath());
+        Assert.assertFalse(Files.exists(latestJob.buildLocalJobDirPath()));
         Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, latestJob);
 
         Assert.assertNull(handler.getSnapshot(label, false));

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -41,6 +41,7 @@ import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
 import org.apache.doris.fs.FileSystemFactory;
 import org.apache.doris.persist.EditLog;
+import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.task.AgentTask;
 import org.apache.doris.task.AgentTaskExecutor;
@@ -798,6 +799,80 @@ public class BackupJobTest {
     }
 
     @Test
+    public void testUnavailableLatestLocalSnapshotRemovesPreviousSnapshot() throws IOException {
+        String label = "reused_local_label";
+        BackupHandler handler = new BackupHandler(env);
+        BackupJob previousJob = new BackupJob(label, dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        Deencapsulation.setField(previousJob, "state", BackupJobState.FINISHED);
+        createLocalSnapshotFiles(previousJob);
+        previousJob.rebindLocalJobDirToCurrentFe();
+        Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, previousJob);
+        Assert.assertNotNull(handler.getSnapshot(label, false));
+
+        BackupJob latestJob = new BackupJob(label, dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        Deencapsulation.setField(latestJob, "state", BackupJobState.FINISHED);
+        latestJob.rebindLocalJobDirToCurrentFe();
+        Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, latestJob);
+
+        Assert.assertNull(handler.getSnapshot(label, false));
+    }
+
+    @Test
+    public void testLocalJobDirPathIsIndependentOfTimeZone() {
+        String originalTimeZone = VariableMgr.getDefaultSessionVariable().getTimeZone();
+        try {
+            VariableMgr.getDefaultSessionVariable().setTimeZone("Asia/Shanghai");
+            BackupJob localJob = new BackupJob("time_zone_independent", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                    env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+            Path originalPath = localJob.buildLocalJobDirPath();
+            localJob.rebindLocalJobDirToCurrentFe();
+            String originalJobInfoPath = localJob.getLocalJobInfoFilePath();
+
+            VariableMgr.getDefaultSessionVariable().setTimeZone("UTC");
+
+            Assert.assertEquals(originalPath, localJob.buildLocalJobDirPath());
+            localJob.rebindLocalJobDirToCurrentFe();
+            Assert.assertEquals(originalJobInfoPath, localJob.getLocalJobInfoFilePath());
+        } finally {
+            VariableMgr.getDefaultSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+
+    @Test
+    public void testRebindRetainsExistingLegacyLocalJobDir() throws IOException {
+        String originalTimeZone = VariableMgr.getDefaultSessionVariable().getTimeZone();
+        try {
+            VariableMgr.getDefaultSessionVariable().setTimeZone("Asia/Shanghai");
+            BackupJob legacyJob = new BackupJob("legacy_time_zone", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                    env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+            String createTimeStr = TimeUtils.longToTimeString(legacyJob.getCreateTime(),
+                    TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
+            Path legacyJobDir = BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize()
+                    .resolve("repo__" + Repository.KEEP_ON_LOCAL_REPO_ID)
+                    .resolve(legacyJob.getLabel() + "__" + createTimeStr);
+            Files.createDirectories(legacyJobDir);
+            Path legacyMetaInfo = Files.createFile(legacyJobDir.resolve(Repository.FILE_META_INFO));
+            Path legacyJobInfo = Files.createFile(legacyJobDir.resolve(Repository.PREFIX_JOB_INFO + createTimeStr));
+            Deencapsulation.setField(legacyJob, "localMetaInfoFilePath", legacyMetaInfo.toString());
+            Deencapsulation.setField(legacyJob, "localJobInfoFilePath", legacyJobInfo.toString());
+
+            VariableMgr.getDefaultSessionVariable().setTimeZone("UTC");
+            legacyJob.rebindLocalJobDirToCurrentFe();
+
+            Assert.assertEquals(legacyMetaInfo.toString(), legacyJob.getLocalMetaInfoFilePath());
+            Assert.assertEquals(legacyJobInfo.toString(), legacyJob.getLocalJobInfoFilePath());
+        } finally {
+            VariableMgr.getDefaultSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+
+    @Test
     public void testCheckpointHandlerDoesNotTouchServingFeLocalJobDir() throws Exception {
         Field checkpointThreadIdField = Env.class.getDeclaredField("checkpointThreadId");
         checkpointThreadIdField.setAccessible(true);
@@ -824,6 +899,8 @@ public class BackupJobTest {
 
             replayHandler.replayAddJob(finishedJob);
             Assert.assertTrue("checkpoint replay must not delete serving FE files", marker.exists());
+            Map<String, BackupJob> localSnapshots = Deencapsulation.getField(replayHandler, "localSnapshots");
+            Assert.assertTrue("checkpoint replay must not register runtime-only snapshots", localSnapshots.isEmpty());
 
             ByteArrayOutputStream bytes = new ByteArrayOutputStream();
             try (DataOutputStream out = new DataOutputStream(bytes)) {
@@ -1190,9 +1267,7 @@ public class BackupJobTest {
         Path jobDirPath = backupJob.buildLocalJobDirPath();
         Files.createDirectories(jobDirPath);
         Assert.assertTrue(Files.createFile(jobDirPath.resolve(Repository.FILE_META_INFO)).toFile().exists());
-        String createTimeStr = TimeUtils.longToTimeString(backupJob.getCreateTime(),
-                TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
-        Assert.assertTrue(Files.createFile(jobDirPath.resolve(Repository.PREFIX_JOB_INFO + createTimeStr))
+        Assert.assertTrue(Files.createFile(jobDirPath.resolve(Repository.PREFIX_JOB_INFO + backupJob.getCreateTime()))
                 .toFile().exists());
         return jobDirPath.toFile();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -748,7 +748,8 @@ public class BackupJobTest {
         unexpiredLocalHandler.replayAddJob(unexpiredLocalFinishedJob);
 
         Assert.assertTrue(unexpiredLocalJobDir.exists());
-        Assert.assertNotNull(unexpiredLocalHandler.getSnapshot("unexpired_local_replay", false));
+        Assert.assertNotNull(unexpiredLocalHandler.getSnapshot(
+                unexpiredLocalDbId, "unexpired_local_replay", false));
     }
 
     @Test
@@ -795,53 +796,69 @@ public class BackupJobTest {
             loadedHandler.readFields(in);
         }
 
-        Assert.assertNull(loadedHandler.getSnapshot("missing_local_image", false));
+        Assert.assertNull(loadedHandler.getSnapshot(dbId, "missing_local_image", false));
     }
 
     @Test
-    public void testUnavailableLatestLocalSnapshotRemovesPreviousSnapshot() throws IOException {
+    public void testUnavailableLatestLocalSnapshotOnlyRemovesSameDatabase() throws IOException {
         String label = "reused_local_label";
+        long createTime = System.currentTimeMillis();
         BackupHandler handler = new BackupHandler(env);
         BackupJob previousJob = new BackupJob(label, dbId, UnitTestUtil.DB_NAME,
                 Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
                 env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
-        Deencapsulation.setField(previousJob, "jobId", 50001L);
+        Deencapsulation.setField(previousJob, "createTime", createTime);
         Deencapsulation.setField(previousJob, "state", BackupJobState.FINISHED);
         createLocalSnapshotFiles(previousJob);
         previousJob.rebindLocalJobDirToCurrentFe();
         Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, previousJob);
-        Assert.assertNotNull(handler.getSnapshot(label, false));
+        Assert.assertNotNull(handler.getSnapshot(dbId, label, false));
+
+        long otherDbId = dbId + 1;
+        BackupJob otherDbJob = new BackupJob(label, otherDbId, "other_db",
+                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 11);
+        // Keep this registry-scoping test independent of the legacy same-second staging collision.
+        Deencapsulation.setField(otherDbJob, "createTime", createTime + 2000);
+        Deencapsulation.setField(otherDbJob, "state", BackupJobState.FINISHED);
+        createLocalSnapshotFiles(otherDbJob);
+        otherDbJob.rebindLocalJobDirToCurrentFe();
+        Deencapsulation.invoke(handler, "addBackupOrRestoreJob", otherDbId, otherDbJob);
+        Assert.assertEquals(0, handler.getSnapshot(dbId, label, false).getCommitSeq());
+        Assert.assertEquals(11, handler.getSnapshot(otherDbId, label, false).getCommitSeq());
 
         BackupJob latestJob = new BackupJob(label, dbId, UnitTestUtil.DB_NAME,
                 Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
                 env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
-        Deencapsulation.setField(latestJob, "jobId", 50002L);
+        Deencapsulation.setField(latestJob, "createTime", createTime + 1000);
         Deencapsulation.setField(latestJob, "state", BackupJobState.FINISHED);
         latestJob.rebindLocalJobDirToCurrentFe();
         Assert.assertNotEquals(previousJob.buildLocalJobDirPath(), latestJob.buildLocalJobDirPath());
         Assert.assertFalse(Files.exists(latestJob.buildLocalJobDirPath()));
         Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, latestJob);
 
-        Assert.assertNull(handler.getSnapshot(label, false));
+        Assert.assertNull(handler.getSnapshot(dbId, label, false));
+        Assert.assertEquals(11, handler.getSnapshot(otherDbId, label, false).getCommitSeq());
     }
 
     @Test
-    public void testLocalJobDirPathIsIndependentOfTimeZone() {
+    public void testLocalJobDirUsesLegacyFormat() {
         String originalTimeZone = VariableMgr.getDefaultSessionVariable().getTimeZone();
         try {
             VariableMgr.getDefaultSessionVariable().setTimeZone("Asia/Shanghai");
-            BackupJob localJob = new BackupJob("time_zone_independent", dbId, UnitTestUtil.DB_NAME,
+            BackupJob localJob = new BackupJob("legacy_staging", dbId, UnitTestUtil.DB_NAME,
                     Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
                     env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
-            Path originalPath = localJob.buildLocalJobDirPath();
-            localJob.rebindLocalJobDirToCurrentFe();
-            String originalJobInfoPath = localJob.getLocalJobInfoFilePath();
+            String createTimeStr = TimeUtils.longToTimeString(localJob.getCreateTime(),
+                    TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
+            Path expectedPath = BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize()
+                    .resolve("repo__" + Repository.KEEP_ON_LOCAL_REPO_ID)
+                    .resolve(localJob.getLabel() + "__" + createTimeStr);
 
-            VariableMgr.getDefaultSessionVariable().setTimeZone("UTC");
-
-            Assert.assertEquals(originalPath, localJob.buildLocalJobDirPath());
+            Assert.assertEquals(expectedPath, localJob.buildLocalJobDirPath());
             localJob.rebindLocalJobDirToCurrentFe();
-            Assert.assertEquals(originalJobInfoPath, localJob.getLocalJobInfoFilePath());
+            Assert.assertEquals(expectedPath.resolve(Repository.PREFIX_JOB_INFO + createTimeStr).toString(),
+                    localJob.getLocalJobInfoFilePath());
         } finally {
             VariableMgr.getDefaultSessionVariable().setTimeZone(originalTimeZone);
         }
@@ -903,7 +920,8 @@ public class BackupJobTest {
 
             replayHandler.replayAddJob(finishedJob);
             Assert.assertTrue("checkpoint replay must not delete serving FE files", marker.exists());
-            Map<String, BackupJob> localSnapshots = Deencapsulation.getField(replayHandler, "localSnapshots");
+            Map<Long, Map<String, BackupJob>> localSnapshots =
+                    Deencapsulation.getField(replayHandler, "localSnapshots");
             Assert.assertTrue("checkpoint replay must not register runtime-only snapshots", localSnapshots.isEmpty());
 
             ByteArrayOutputStream bytes = new ByteArrayOutputStream();
@@ -1269,9 +1287,11 @@ public class BackupJobTest {
 
     private File createLocalSnapshotFiles(BackupJob backupJob) throws IOException {
         Path jobDirPath = backupJob.buildLocalJobDirPath();
+        String createTimeStr = TimeUtils.longToTimeString(backupJob.getCreateTime(),
+                TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
         Files.createDirectories(jobDirPath);
         Assert.assertTrue(Files.createFile(jobDirPath.resolve(Repository.FILE_META_INFO)).toFile().exists());
-        Assert.assertTrue(Files.createFile(jobDirPath.resolve(Repository.PREFIX_JOB_INFO + backupJob.getCreateTime()))
+        Assert.assertTrue(Files.createFile(jobDirPath.resolve(Repository.PREFIX_JOB_INFO + createTimeStr))
                 .toFile().exists());
         return jobDirPath.toFile();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -588,8 +588,8 @@ public class BackupJobTest {
 
     /**
      * Active getSnapshot readers pin the staging dir via refcount; cleanup is deferred
-     * until the last reader releases, so mid-read deletion cannot corrupt materialization.
-     * Job state monitor is not required for this coordination.
+     * to a later handler cleanup cycle after the last reader releases, so neither
+     * mid-read deletion nor directory IO on the RPC thread can occur.
      */
     @Test
     public void testLocalSnapshotCleanupDefersWhileGetSnapshotReaderPinned() throws Exception {
@@ -615,10 +615,14 @@ public class BackupJobTest {
         Deencapsulation.setField(localSnapshotJob, "localJobDirReaders", 1);
         localSnapshotJob.cleanupLocalJobDirAfterRemoved();
         Assert.assertTrue("cleanup must defer while a reader is pinned", localJobDir.exists());
-        Assert.assertTrue(Deencapsulation.getField(localSnapshotJob, "localJobDirCleanupPending"));
 
-        // Release the pin (readers 1 -> 0); deferred cleanup should run.
+        // Release the pin (readers 1 -> 0); the RPC reader must not run directory IO.
         Deencapsulation.invoke(localSnapshotJob, "releaseLocalJobDirRead");
+        Assert.assertTrue(localJobDir.exists());
+        Assert.assertFalse(Deencapsulation.getField(localSnapshotJob, "localJobDirCleaned"));
+
+        // A later backup handler cleanup cycle performs the deferred deletion.
+        Assert.assertTrue(localSnapshotJob.cleanupLocalJobDirAfterRemoved());
         Assert.assertFalse(localJobDir.exists());
         Assert.assertTrue(Deencapsulation.getField(localSnapshotJob, "localJobDirCleaned"));
     }
@@ -744,10 +748,7 @@ public class BackupJobTest {
         Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
         Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
 
-        localSnapshotJob.cleanupLocalJobDirIfNecessary(createTime + 999);
-        Assert.assertTrue(localJobDir.exists());
-
-        localSnapshotJob.cleanupLocalJobDirIfNecessary(createTime + 1000);
+        localSnapshotJob.cleanupLocalJobDirIfNecessary(createTime);
         Assert.assertFalse(localJobDir.exists());
     }
 
@@ -808,8 +809,9 @@ public class BackupJobTest {
             Assert.assertEquals(1, pendingCleanupJobs.size());
 
             Deencapsulation.invoke(evictedJob, "releaseLocalJobDirRead");
-            Assert.assertFalse(localJobDir.exists());
+            Assert.assertTrue(localJobDir.exists());
             Deencapsulation.invoke(backupHandler, "cleanupPendingBackupJobLocalJobDirs");
+            Assert.assertFalse(localJobDir.exists());
             Assert.assertTrue(pendingCleanupJobs.isEmpty());
         } finally {
             Config.max_backup_restore_job_num_per_db = oldMaxJobNum;
@@ -898,6 +900,34 @@ public class BackupJobTest {
             }
             Files.deleteIfExists(externalDir);
             Config.backup_orphan_dir_keep_max_second = oldOrphanKeepSecond;
+        }
+    }
+
+    @Test
+    public void testOrphanJobDirCleanupUsesIndependentInterval() throws Exception {
+        long oldCleanupIntervalSecond = Config.backup_orphan_dir_cleanup_interval_second;
+        Config.backup_orphan_dir_cleanup_interval_second = 3600;
+        try {
+            long nowMs = System.currentTimeMillis();
+
+            File firstOldOrphanDir = createRepoJobDir(repoId, "first_interval_orphan");
+            Files.setLastModifiedTime(firstOldOrphanDir.toPath(),
+                    FileTime.fromMillis(nowMs - TimeUnit.DAYS.toMillis(3)));
+            Deencapsulation.invoke(backupHandler, "cleanupOrphanBackupJobLocalJobDirsIfNecessary", nowMs);
+            Assert.assertFalse(firstOldOrphanDir.exists());
+
+            File secondOldOrphanDir = createRepoJobDir(repoId, "second_interval_orphan");
+            Files.setLastModifiedTime(secondOldOrphanDir.toPath(),
+                    FileTime.fromMillis(nowMs - TimeUnit.DAYS.toMillis(3)));
+            Deencapsulation.invoke(backupHandler, "cleanupOrphanBackupJobLocalJobDirsIfNecessary",
+                    nowMs + Config.backup_handler_update_interval_millis);
+            Assert.assertTrue(secondOldOrphanDir.exists());
+
+            Deencapsulation.invoke(backupHandler, "cleanupOrphanBackupJobLocalJobDirsIfNecessary",
+                    nowMs + TimeUnit.HOURS.toMillis(1));
+            Assert.assertFalse(secondOldOrphanDir.exists());
+        } finally {
+            Config.backup_orphan_dir_cleanup_interval_second = oldCleanupIntervalSecond;
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -35,13 +35,11 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.GZIPUtils;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
-import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.UnitTestUtil;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
 import org.apache.doris.fs.FileSystemFactory;
 import org.apache.doris.persist.EditLog;
-import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.task.AgentTask;
 import org.apache.doris.task.AgentTaskExecutor;
@@ -67,8 +65,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -77,10 +73,14 @@ import java.io.RandomAccessFile;
 import java.lang.reflect.Field;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class BackupJobTest {
@@ -391,6 +391,9 @@ public class BackupJobTest {
         job.run();
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(BackupJobState.FINISHED, job.getState());
+        Assert.assertTrue(localJobDir.exists());
+
+        job.cleanupLocalJobDirIfNecessary(job.getCreateTime() + job.getTimeoutMs());
         Assert.assertFalse(localJobDir.exists());
     }
 
@@ -421,7 +424,7 @@ public class BackupJobTest {
     }
 
     @Test
-    public void testCleanupFinishedRemoteBackupJobDirFromPersistedFilePaths() throws IOException {
+    public void testCleanupFinishedRemoteBackupJobDirOnlyAfterExpired() throws IOException {
         File localJobDir = createLocalJobDir("remote_cleanup");
         File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
         File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-09-10-00-00");
@@ -429,12 +432,17 @@ public class BackupJobTest {
         Assert.assertTrue(jobInfo.createNewFile());
 
         Deencapsulation.setField(job, "state", BackupJobState.FINISHED);
+        long createTime = System.currentTimeMillis();
+        Deencapsulation.setField(job, "createTime", createTime);
+        Deencapsulation.setField(job, "timeoutMs", 1000L);
         Deencapsulation.setField(job, "localJobDirPath", null);
         Deencapsulation.setField(job, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
         Deencapsulation.setField(job, "localJobInfoFilePath", jobInfo.getAbsolutePath());
 
-        job.cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
+        job.cleanupLocalJobDirIfNecessary(createTime + 999);
+        Assert.assertTrue(localJobDir.exists());
 
+        job.cleanupLocalJobDirIfNecessary(createTime + 1000);
         Assert.assertFalse(localJobDir.exists());
     }
 
@@ -639,317 +647,19 @@ public class BackupJobTest {
         Assert.assertTrue(jobInfo.createNewFile());
 
         Deencapsulation.setField(localSnapshotJob, "state", BackupJobState.CANCELLED);
+        long createTime = System.currentTimeMillis();
+        Deencapsulation.setField(localSnapshotJob, "createTime", createTime);
         Deencapsulation.setField(localSnapshotJob, "localJobDirPath", null);
         Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
         Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
 
-        localSnapshotJob.cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
+        localSnapshotJob.cleanupLocalJobDirIfNecessary(createTime + 3600 * 1000);
         Assert.assertTrue(localJobDir.exists());
         Assert.assertFalse(Deencapsulation.getField(localSnapshotJob, "localJobDirCleaned"));
-        Assert.assertEquals(metaInfo.getAbsolutePath(), localSnapshotJob.getLocalMetaInfoFilePath());
-        Assert.assertEquals(jobInfo.getAbsolutePath(), localSnapshotJob.getLocalJobInfoFilePath());
 
-        localSnapshotJob.cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
+        localSnapshotJob.cleanupLocalJobDirIfNecessary(createTime + 3600 * 1000);
         Assert.assertFalse(localJobDir.exists());
         Assert.assertTrue(Deencapsulation.getField(localSnapshotJob, "localJobDirCleaned"));
-        Assert.assertNull(localSnapshotJob.getLocalMetaInfoFilePath());
-        Assert.assertNull(localSnapshotJob.getLocalJobInfoFilePath());
-    }
-
-    @Test
-    public void testCheckpointReplayDoesNotMaterializeLocalJobDir() throws Exception {
-        BackupJob replayJob = new BackupJob("checkpoint_replay", dbId, UnitTestUtil.DB_NAME,
-                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                env, repoId, 0);
-        Deencapsulation.setField(replayJob, "state", BackupJobState.SAVE_META);
-
-        String createTimeStr = TimeUtils.longToTimeString(replayJob.getCreateTime(),
-                TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
-        Path jobDir = BackupHandler.BACKUP_ROOT_DIR.resolve("repo__" + repoId)
-                .resolve("checkpoint_replay__" + createTimeStr);
-        Files.createDirectories(jobDir);
-        Path marker = jobDir.resolve("checkpoint_marker");
-        Files.createFile(marker);
-
-        Field checkpointThreadIdField = Env.class.getDeclaredField("checkpointThreadId");
-        checkpointThreadIdField.setAccessible(true);
-        long checkpointThreadId = checkpointThreadIdField.getLong(null);
-        checkpointThreadIdField.setLong(null, Thread.currentThread().getId());
-        try {
-            replayJob.replayRun();
-        } finally {
-            checkpointThreadIdField.setLong(null, checkpointThreadId);
-        }
-
-        Assert.assertTrue("checkpoint replay must not replace serving FE staging files", Files.exists(marker));
-    }
-
-    @Test
-    public void testReplayTerminalJobCleanupPolicy() throws IOException {
-        BackupHandler remoteHandler = new BackupHandler(env);
-        BackupJob remotePendingJob = new BackupJob("remote_replay", dbId, UnitTestUtil.DB_NAME,
-                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                env, repoId, 0);
-        remoteHandler.replayAddJob(remotePendingJob);
-
-        BackupJob remoteFinishedJob = new BackupJob("remote_replay", dbId, UnitTestUtil.DB_NAME,
-                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                env, repoId, 0);
-        Deencapsulation.setField(remoteFinishedJob, "state", BackupJobState.FINISHED);
-        File remoteJobDir = createLocalSnapshotFiles(remoteFinishedJob);
-        File foreignRemoteJobDir = createLocalJobDir("foreign_fe_remote_replay");
-        File foreignMetaInfo = new File(foreignRemoteJobDir, Repository.FILE_META_INFO);
-        File foreignJobInfo = new File(foreignRemoteJobDir, Repository.PREFIX_JOB_INFO + "foreign");
-        Assert.assertTrue(foreignMetaInfo.createNewFile());
-        Assert.assertTrue(foreignJobInfo.createNewFile());
-        Deencapsulation.setField(remoteFinishedJob, "localMetaInfoFilePath", foreignMetaInfo.getAbsolutePath());
-        Deencapsulation.setField(remoteFinishedJob, "localJobInfoFilePath", foreignJobInfo.getAbsolutePath());
-
-        remoteHandler.replayAddJob(remoteFinishedJob);
-
-        Assert.assertFalse(remoteJobDir.exists());
-        Assert.assertTrue("replay must not clean another FE's persisted path", foreignRemoteJobDir.exists());
-        Assert.assertNull(remoteFinishedJob.getLocalMetaInfoFilePath());
-        Assert.assertNull(remoteFinishedJob.getLocalJobInfoFilePath());
-
-        long localDbId = dbId + 1;
-        BackupHandler expiredLocalHandler = new BackupHandler(env);
-        BackupJob expiredLocalPendingJob = new BackupJob("expired_local_replay", localDbId, UnitTestUtil.DB_NAME,
-                Lists.newArrayList(), 1, BackupStmt.BackupContent.ALL,
-                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
-        expiredLocalHandler.replayAddJob(expiredLocalPendingJob);
-
-        BackupJob expiredLocalFinishedJob = new BackupJob("expired_local_replay", localDbId,
-                UnitTestUtil.DB_NAME, Lists.newArrayList(), 1, BackupStmt.BackupContent.ALL,
-                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
-        Deencapsulation.setField(expiredLocalFinishedJob, "state", BackupJobState.FINISHED);
-        Deencapsulation.setField(expiredLocalFinishedJob, "createTime", System.currentTimeMillis() - 1000);
-        File expiredLocalJobDir = createLocalSnapshotFiles(expiredLocalFinishedJob);
-        setForeignLocalSnapshotPaths(expiredLocalFinishedJob);
-
-        expiredLocalHandler.replayAddJob(expiredLocalFinishedJob);
-
-        Assert.assertFalse(expiredLocalJobDir.exists());
-
-        long unexpiredLocalDbId = dbId + 2;
-        BackupHandler unexpiredLocalHandler = new BackupHandler(env);
-        BackupJob unexpiredLocalPendingJob = new BackupJob("unexpired_local_replay", unexpiredLocalDbId,
-                UnitTestUtil.DB_NAME, Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
-        unexpiredLocalHandler.replayAddJob(unexpiredLocalPendingJob);
-
-        BackupJob unexpiredLocalFinishedJob = new BackupJob("unexpired_local_replay", unexpiredLocalDbId,
-                UnitTestUtil.DB_NAME, Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
-        Deencapsulation.setField(unexpiredLocalFinishedJob, "state", BackupJobState.FINISHED);
-        File unexpiredLocalJobDir = createLocalSnapshotFiles(unexpiredLocalFinishedJob);
-        setForeignLocalSnapshotPaths(unexpiredLocalFinishedJob);
-
-        unexpiredLocalHandler.replayAddJob(unexpiredLocalFinishedJob);
-
-        Assert.assertTrue(unexpiredLocalJobDir.exists());
-        Assert.assertNotNull(unexpiredLocalHandler.getSnapshot(
-                unexpiredLocalDbId, "unexpired_local_replay", false));
-    }
-
-    @Test
-    public void testImageLoadRebindsAndCleansFinishedRemoteJobDir() throws IOException {
-        BackupHandler serializedHandler = new BackupHandler(env);
-        BackupJob remoteFinishedJob = new BackupJob("image_remote", dbId, UnitTestUtil.DB_NAME,
-                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                env, repoId, 0);
-        Deencapsulation.setField(remoteFinishedJob, "state", BackupJobState.FINISHED);
-        File remoteJobDir = createLocalSnapshotFiles(remoteFinishedJob);
-        setForeignLocalSnapshotPaths(remoteFinishedJob);
-        Deencapsulation.invoke(serializedHandler, "addBackupOrRestoreJob", dbId, remoteFinishedJob);
-
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        try (DataOutputStream out = new DataOutputStream(bytes)) {
-            serializedHandler.write(out);
-        }
-
-        BackupHandler loadedHandler = new BackupHandler();
-        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
-            loadedHandler.readFields(in);
-        }
-
-        Assert.assertFalse(remoteJobDir.exists());
-    }
-
-    @Test
-    public void testImageLoadDoesNotRegisterUnavailableLocalSnapshot() throws IOException {
-        BackupHandler serializedHandler = new BackupHandler(env);
-        BackupJob localFinishedJob = new BackupJob("missing_local_image", dbId, UnitTestUtil.DB_NAME,
-                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
-        Deencapsulation.setField(localFinishedJob, "state", BackupJobState.FINISHED);
-        setForeignLocalSnapshotPaths(localFinishedJob);
-        Deencapsulation.invoke(serializedHandler, "addBackupOrRestoreJob", dbId, localFinishedJob);
-
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        try (DataOutputStream out = new DataOutputStream(bytes)) {
-            serializedHandler.write(out);
-        }
-
-        BackupHandler loadedHandler = new BackupHandler();
-        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
-            loadedHandler.readFields(in);
-        }
-
-        Assert.assertNull(loadedHandler.getSnapshot(dbId, "missing_local_image", false));
-    }
-
-    @Test
-    public void testUnavailableLatestLocalSnapshotOnlyRemovesSameDatabase() throws IOException {
-        String label = "reused_local_label";
-        long createTime = System.currentTimeMillis();
-        BackupHandler handler = new BackupHandler(env);
-        BackupJob previousJob = new BackupJob(label, dbId, UnitTestUtil.DB_NAME,
-                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
-        Deencapsulation.setField(previousJob, "createTime", createTime);
-        Deencapsulation.setField(previousJob, "state", BackupJobState.FINISHED);
-        createLocalSnapshotFiles(previousJob);
-        previousJob.rebindLocalJobDirToCurrentFe();
-        Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, previousJob);
-        Assert.assertNotNull(handler.getSnapshot(dbId, label, false));
-
-        long otherDbId = dbId + 1;
-        BackupJob otherDbJob = new BackupJob(label, otherDbId, "other_db",
-                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                env, Repository.KEEP_ON_LOCAL_REPO_ID, 11);
-        // Keep this registry-scoping test independent of the legacy same-second staging collision.
-        Deencapsulation.setField(otherDbJob, "createTime", createTime + 2000);
-        Deencapsulation.setField(otherDbJob, "state", BackupJobState.FINISHED);
-        createLocalSnapshotFiles(otherDbJob);
-        otherDbJob.rebindLocalJobDirToCurrentFe();
-        Deencapsulation.invoke(handler, "addBackupOrRestoreJob", otherDbId, otherDbJob);
-        Assert.assertEquals(0, handler.getSnapshot(dbId, label, false).getCommitSeq());
-        Assert.assertEquals(11, handler.getSnapshot(otherDbId, label, false).getCommitSeq());
-
-        BackupJob latestJob = new BackupJob(label, dbId, UnitTestUtil.DB_NAME,
-                Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
-        Deencapsulation.setField(latestJob, "createTime", createTime + 1000);
-        Deencapsulation.setField(latestJob, "state", BackupJobState.FINISHED);
-        latestJob.rebindLocalJobDirToCurrentFe();
-        Assert.assertNotEquals(previousJob.buildLocalJobDirPath(), latestJob.buildLocalJobDirPath());
-        Assert.assertFalse(Files.exists(latestJob.buildLocalJobDirPath()));
-        Deencapsulation.invoke(handler, "addBackupOrRestoreJob", dbId, latestJob);
-
-        Assert.assertNull(handler.getSnapshot(dbId, label, false));
-        Assert.assertEquals(11, handler.getSnapshot(otherDbId, label, false).getCommitSeq());
-    }
-
-    @Test
-    public void testLocalJobDirUsesLegacyFormat() {
-        String originalTimeZone = VariableMgr.getDefaultSessionVariable().getTimeZone();
-        try {
-            VariableMgr.getDefaultSessionVariable().setTimeZone("Asia/Shanghai");
-            BackupJob localJob = new BackupJob("legacy_staging", dbId, UnitTestUtil.DB_NAME,
-                    Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                    env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
-            String createTimeStr = TimeUtils.longToTimeString(localJob.getCreateTime(),
-                    TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
-            Path expectedPath = BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize()
-                    .resolve("repo__" + Repository.KEEP_ON_LOCAL_REPO_ID)
-                    .resolve(localJob.getLabel() + "__" + createTimeStr);
-
-            Assert.assertEquals(expectedPath, localJob.buildLocalJobDirPath());
-            localJob.rebindLocalJobDirToCurrentFe();
-            Assert.assertEquals(expectedPath.resolve(Repository.PREFIX_JOB_INFO + createTimeStr).toString(),
-                    localJob.getLocalJobInfoFilePath());
-        } finally {
-            VariableMgr.getDefaultSessionVariable().setTimeZone(originalTimeZone);
-        }
-    }
-
-    @Test
-    public void testRebindRetainsExistingLegacyLocalJobDir() throws IOException {
-        String originalTimeZone = VariableMgr.getDefaultSessionVariable().getTimeZone();
-        try {
-            VariableMgr.getDefaultSessionVariable().setTimeZone("Asia/Shanghai");
-            BackupJob legacyJob = new BackupJob("legacy_time_zone", dbId, UnitTestUtil.DB_NAME,
-                    Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                    env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
-            String createTimeStr = TimeUtils.longToTimeString(legacyJob.getCreateTime(),
-                    TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
-            Path legacyJobDir = BackupHandler.BACKUP_ROOT_DIR.toAbsolutePath().normalize()
-                    .resolve("repo__" + Repository.KEEP_ON_LOCAL_REPO_ID)
-                    .resolve(legacyJob.getLabel() + "__" + createTimeStr);
-            Files.createDirectories(legacyJobDir);
-            Path legacyMetaInfo = Files.createFile(legacyJobDir.resolve(Repository.FILE_META_INFO));
-            Path legacyJobInfo = Files.createFile(legacyJobDir.resolve(Repository.PREFIX_JOB_INFO + createTimeStr));
-            Deencapsulation.setField(legacyJob, "localMetaInfoFilePath", legacyMetaInfo.toString());
-            Deencapsulation.setField(legacyJob, "localJobInfoFilePath", legacyJobInfo.toString());
-
-            VariableMgr.getDefaultSessionVariable().setTimeZone("UTC");
-            legacyJob.rebindLocalJobDirToCurrentFe();
-
-            Assert.assertEquals(legacyMetaInfo.toString(), legacyJob.getLocalMetaInfoFilePath());
-            Assert.assertEquals(legacyJobInfo.toString(), legacyJob.getLocalJobInfoFilePath());
-        } finally {
-            VariableMgr.getDefaultSessionVariable().setTimeZone(originalTimeZone);
-        }
-    }
-
-    @Test
-    public void testCheckpointHandlerDoesNotTouchServingFeLocalJobDir() throws Exception {
-        Field checkpointThreadIdField = Env.class.getDeclaredField("checkpointThreadId");
-        checkpointThreadIdField.setAccessible(true);
-        long checkpointThreadId = checkpointThreadIdField.getLong(null);
-        checkpointThreadIdField.setLong(null, Thread.currentThread().getId());
-        try {
-            File markerDir = createLocalJobDir("checkpoint_handler_marker");
-            File marker = new File(markerDir, "serving_fe_marker");
-            Assert.assertTrue(marker.createNewFile());
-
-            BackupHandler replayHandler = new BackupHandler(env);
-            BackupJob pendingJob = new BackupJob("checkpoint_handler", dbId, UnitTestUtil.DB_NAME,
-                    Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                    env, repoId, 0);
-            replayHandler.replayAddJob(pendingJob);
-            BackupJob finishedJob = new BackupJob("checkpoint_handler", dbId, UnitTestUtil.DB_NAME,
-                    Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                    env, repoId, 0);
-            Deencapsulation.setField(finishedJob, "state", BackupJobState.FINISHED);
-            Deencapsulation.setField(finishedJob, "localMetaInfoFilePath",
-                    new File(markerDir, Repository.FILE_META_INFO).getAbsolutePath());
-            Deencapsulation.setField(finishedJob, "localJobInfoFilePath",
-                    new File(markerDir, Repository.PREFIX_JOB_INFO + "checkpoint").getAbsolutePath());
-
-            replayHandler.replayAddJob(finishedJob);
-            Assert.assertTrue("checkpoint replay must not delete serving FE files", marker.exists());
-            Map<Long, Map<String, BackupJob>> localSnapshots =
-                    Deencapsulation.getField(replayHandler, "localSnapshots");
-            Assert.assertTrue("checkpoint replay must not register runtime-only snapshots", localSnapshots.isEmpty());
-
-            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-            try (DataOutputStream out = new DataOutputStream(bytes)) {
-                replayHandler.write(out);
-            }
-            BackupHandler loadedHandler = new BackupHandler();
-            try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
-                loadedHandler.readFields(in);
-            }
-            Assert.assertTrue("checkpoint image load must not delete serving FE files", marker.exists());
-
-            int previousMaxJobNum = Config.max_backup_restore_job_num_per_db;
-            try {
-                Config.max_backup_restore_job_num_per_db = 1;
-                BackupHandler evictionHandler = new BackupHandler(env);
-                Deencapsulation.invoke(evictionHandler, "addBackupOrRestoreJob", dbId, finishedJob);
-                BackupJob replacementJob = new BackupJob("checkpoint_replacement", dbId, UnitTestUtil.DB_NAME,
-                        Lists.newArrayList(), 3600 * 1000, BackupStmt.BackupContent.ALL,
-                        env, repoId, 0);
-                Deencapsulation.invoke(evictionHandler, "addBackupOrRestoreJob", dbId, replacementJob);
-                Assert.assertTrue("checkpoint queue eviction must not delete serving FE files", marker.exists());
-            } finally {
-                Config.max_backup_restore_job_num_per_db = previousMaxJobNum;
-            }
-        } finally {
-            checkpointThreadIdField.setLong(null, checkpointThreadId);
-        }
     }
 
     @Test
@@ -1030,13 +740,167 @@ public class BackupJobTest {
         Assert.assertTrue(jobInfo.createNewFile());
 
         Deencapsulation.setField(localSnapshotJob, "state", BackupJobState.CANCELLED);
+        long createTime = System.currentTimeMillis();
+        Deencapsulation.setField(localSnapshotJob, "createTime", createTime);
         Deencapsulation.setField(localSnapshotJob, "localJobDirPath", null);
         Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
         Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
 
-        localSnapshotJob.cleanupLocalJobDirIfNecessary(System.currentTimeMillis());
+        localSnapshotJob.cleanupLocalJobDirIfNecessary(createTime + 999);
+        Assert.assertTrue(localJobDir.exists());
 
+        localSnapshotJob.cleanupLocalJobDirIfNecessary(createTime + 1000);
         Assert.assertFalse(localJobDir.exists());
+    }
+
+    @Test
+    public void testExpiredGetSnapshotDoesNotDeleteJobDir() throws IOException {
+        BackupJob localSnapshotJob = new BackupJob("local_label", dbId, UnitTestUtil.DB_NAME,
+                Lists.newArrayList(), 1000, BackupStmt.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+        File localJobDir = createLocalJobDir("expired_snapshot_rpc");
+        File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
+        File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-15-10-00-00");
+        Assert.assertTrue(metaInfo.createNewFile());
+        Assert.assertTrue(jobInfo.createNewFile());
+
+        long createTime = System.currentTimeMillis() - 1000;
+        Deencapsulation.setField(localSnapshotJob, "state", BackupJobState.FINISHED);
+        Deencapsulation.setField(localSnapshotJob, "createTime", createTime);
+        Deencapsulation.setField(localSnapshotJob, "localJobDirPath", null);
+        Deencapsulation.setField(localSnapshotJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+        Deencapsulation.setField(localSnapshotJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+
+        Snapshot snapshot = localSnapshotJob.getSnapshot(false);
+        Assert.assertTrue(snapshot.isExpired());
+        Assert.assertTrue(localJobDir.exists());
+
+        localSnapshotJob.cleanupLocalJobDirIfNecessary(createTime + 1000);
+        Assert.assertFalse(localJobDir.exists());
+    }
+
+    @Test
+    public void testEvictedJobCleanupWaitsForPinnedReader() throws Exception {
+        int oldMaxJobNum = Config.max_backup_restore_job_num_per_db;
+        Config.max_backup_restore_job_num_per_db = 1;
+        try {
+            BackupJob evictedJob = new BackupJob("evicted_label", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 1000, BackupStmt.BackupContent.ALL, env, repoId, 0);
+            File localJobDir = createLocalJobDir("evicted_snapshot");
+            File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
+            File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-15-11-00-00");
+            Assert.assertTrue(metaInfo.createNewFile());
+            Assert.assertTrue(jobInfo.createNewFile());
+            Deencapsulation.setField(evictedJob, "state", BackupJobState.FINISHED);
+            Deencapsulation.setField(evictedJob, "localJobDirPath", null);
+            Deencapsulation.setField(evictedJob, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
+            Deencapsulation.setField(evictedJob, "localJobInfoFilePath", jobInfo.getAbsolutePath());
+            Deencapsulation.setField(evictedJob, "localJobDirReaders", 1);
+
+            BackupJob replacementJob = new BackupJob("replacement_label", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 1000, BackupStmt.BackupContent.ALL, env, repoId, 0);
+            Deencapsulation.invoke(backupHandler, "addBackupOrRestoreJob", dbId, evictedJob);
+            Deencapsulation.invoke(backupHandler, "addBackupOrRestoreJob", dbId, replacementJob);
+
+            Deque<BackupJob> pendingCleanupJobs = Deencapsulation.getField(
+                    backupHandler, "pendingCleanupJobs");
+            Assert.assertEquals(1, pendingCleanupJobs.size());
+            Deencapsulation.invoke(backupHandler, "cleanupPendingBackupJobLocalJobDirs");
+            Assert.assertTrue(localJobDir.exists());
+            Assert.assertEquals(1, pendingCleanupJobs.size());
+
+            Deencapsulation.invoke(evictedJob, "releaseLocalJobDirRead");
+            Assert.assertFalse(localJobDir.exists());
+            Deencapsulation.invoke(backupHandler, "cleanupPendingBackupJobLocalJobDirs");
+            Assert.assertTrue(pendingCleanupJobs.isEmpty());
+        } finally {
+            Config.max_backup_restore_job_num_per_db = oldMaxJobNum;
+        }
+    }
+
+    @Test
+    public void testCheckpointReplayAndEvictionDoNotTouchJobDirs() throws Exception {
+        Field checkpointThreadIdField = Env.class.getDeclaredField("checkpointThreadId");
+        checkpointThreadIdField.setAccessible(true);
+        long oldCheckpointThreadId = checkpointThreadIdField.getLong(null);
+        int oldMaxJobNum = Config.max_backup_restore_job_num_per_db;
+        Config.max_backup_restore_job_num_per_db = 1;
+        checkpointThreadIdField.setLong(null, Thread.currentThread().getId());
+        try {
+            Deencapsulation.setField(job, "state", BackupJobState.SAVE_META);
+            job.replayRun();
+            Assert.assertNull(job.getLocalMetaInfoFilePath());
+            Assert.assertNull(job.getLocalJobInfoFilePath());
+
+            BackupJob finishedJob = new BackupJob("checkpoint_finished", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 1000, BackupStmt.BackupContent.ALL, env, repoId, 0);
+            File localJobDir = createLocalJobDir("checkpoint_eviction");
+            Deencapsulation.setField(finishedJob, "state", BackupJobState.FINISHED);
+            Deencapsulation.setField(finishedJob, "localJobDirPath", localJobDir.toPath());
+            BackupJob replacementJob = new BackupJob("checkpoint_replacement", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), 1000, BackupStmt.BackupContent.ALL, env, repoId, 0);
+
+            Deencapsulation.invoke(backupHandler, "addBackupOrRestoreJob", dbId, finishedJob);
+            Deencapsulation.invoke(backupHandler, "addBackupOrRestoreJob", dbId, replacementJob);
+
+            Deque<BackupJob> pendingCleanupJobs = Deencapsulation.getField(
+                    backupHandler, "pendingCleanupJobs");
+            Assert.assertTrue(pendingCleanupJobs.isEmpty());
+            Assert.assertTrue(localJobDir.exists());
+        } finally {
+            checkpointThreadIdField.setLong(null, oldCheckpointThreadId);
+            Config.max_backup_restore_job_num_per_db = oldMaxJobNum;
+        }
+    }
+
+    @Test
+    public void testOrphanJobDirCleanupUsesReferencesAndGracePeriod() throws Exception {
+        int oldOrphanKeepSecond = Config.backup_orphan_dir_keep_max_second;
+        Config.backup_orphan_dir_keep_max_second = 2 * 24 * 3600;
+        Path externalDir = Files.createTempDirectory("backup_orphan_external");
+        Path symlink = null;
+        try {
+            long nowMs = System.currentTimeMillis();
+            File referencedDir = createRepoJobDir(repoId, "referenced");
+            File oldOrphanDir = createRepoJobDir(repoId, "old_orphan");
+            File newOrphanDir = createRepoJobDir(repoId, "new_orphan");
+            Files.setLastModifiedTime(referencedDir.toPath(),
+                    FileTime.fromMillis(nowMs - TimeUnit.DAYS.toMillis(3)));
+            Files.setLastModifiedTime(oldOrphanDir.toPath(),
+                    FileTime.fromMillis(nowMs - TimeUnit.DAYS.toMillis(3)));
+
+            BackupJob referencedJob = new BackupJob("referenced_label", dbId, UnitTestUtil.DB_NAME,
+                    Lists.newArrayList(), TimeUnit.DAYS.toMillis(7), BackupStmt.BackupContent.ALL,
+                    env, repoId, 0);
+            Deencapsulation.setField(referencedJob, "state", BackupJobState.FINISHED);
+            Deencapsulation.setField(referencedJob, "localJobDirPath", referencedDir.toPath());
+            Deencapsulation.invoke(backupHandler, "addBackupOrRestoreJob", dbId, referencedJob);
+
+            Path repoDir = referencedDir.toPath().getParent();
+            symlink = repoDir.resolve("orphan_symlink_" + id.getAndIncrement());
+            Files.createSymbolicLink(symlink, externalDir);
+
+            Deencapsulation.invoke(backupHandler, "cleanupOrphanBackupJobLocalJobDirs", nowMs);
+
+            Assert.assertTrue(referencedDir.exists());
+            Assert.assertFalse(oldOrphanDir.exists());
+            Assert.assertTrue(newOrphanDir.exists());
+            Assert.assertTrue(Files.exists(symlink, LinkOption.NOFOLLOW_LINKS));
+            Assert.assertTrue(Files.exists(externalDir));
+
+            File disabledCleanupOrphanDir = createRepoJobDir(repoId, "disabled_cleanup_orphan");
+            Files.setLastModifiedTime(disabledCleanupOrphanDir.toPath(),
+                    FileTime.fromMillis(nowMs - TimeUnit.DAYS.toMillis(3)));
+            Config.backup_orphan_dir_keep_max_second = 0;
+            Deencapsulation.invoke(backupHandler, "cleanupOrphanBackupJobLocalJobDirs", nowMs);
+            Assert.assertTrue(disabledCleanupOrphanDir.exists());
+        } finally {
+            if (symlink != null) {
+                Files.deleteIfExists(symlink);
+            }
+            Files.deleteIfExists(externalDir);
+            Config.backup_orphan_dir_keep_max_second = oldOrphanKeepSecond;
+        }
     }
 
     /**
@@ -1285,20 +1149,11 @@ public class BackupJobTest {
         return jobDirPath.toFile();
     }
 
-    private File createLocalSnapshotFiles(BackupJob backupJob) throws IOException {
-        Path jobDirPath = backupJob.buildLocalJobDirPath();
-        String createTimeStr = TimeUtils.longToTimeString(backupJob.getCreateTime(),
-                TimeUtils.getDatetimeFormatWithHyphenWithTimeZone());
+    private File createRepoJobDir(long jobRepoId, String name) throws IOException {
+        Path jobDirPath = BackupHandler.BACKUP_ROOT_DIR.resolve("repo__" + jobRepoId)
+                .resolve(name + "_" + id.getAndIncrement());
         Files.createDirectories(jobDirPath);
-        Assert.assertTrue(Files.createFile(jobDirPath.resolve(Repository.FILE_META_INFO)).toFile().exists());
-        Assert.assertTrue(Files.createFile(jobDirPath.resolve(Repository.PREFIX_JOB_INFO + createTimeStr))
-                .toFile().exists());
         return jobDirPath.toFile();
-    }
-
-    private void setForeignLocalSnapshotPaths(BackupJob backupJob) {
-        Deencapsulation.setField(backupJob, "localMetaInfoFilePath", "/foreign-fe/tmp/backup/__meta");
-        Deencapsulation.setField(backupJob, "localJobInfoFilePath", "/foreign-fe/tmp/backup/__job_info");
     }
 
     private void createSparseFile(File file, long logicalSize) throws IOException {

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -393,7 +393,8 @@ public class BackupJobTest {
         Assert.assertEquals(BackupJobState.FINISHED, job.getState());
         Assert.assertTrue(localJobDir.exists());
 
-        job.cleanupLocalJobDirIfNecessary(job.getCreateTime() + job.getTimeoutMs());
+        // BackupHandler invokes cleanup after job.run() in the same daemon cycle.
+        job.cleanupLocalJobDirIfNecessary(job.getCreateTime());
         Assert.assertFalse(localJobDir.exists());
     }
 
@@ -424,7 +425,7 @@ public class BackupJobTest {
     }
 
     @Test
-    public void testCleanupFinishedRemoteBackupJobDirOnlyAfterExpired() throws IOException {
+    public void testCleanupFinishedRemoteBackupJobDirImmediately() throws IOException {
         File localJobDir = createLocalJobDir("remote_cleanup");
         File metaInfo = new File(localJobDir, Repository.FILE_META_INFO);
         File jobInfo = new File(localJobDir, Repository.PREFIX_JOB_INFO + "2026-07-09-10-00-00");
@@ -439,10 +440,7 @@ public class BackupJobTest {
         Deencapsulation.setField(job, "localMetaInfoFilePath", metaInfo.getAbsolutePath());
         Deencapsulation.setField(job, "localJobInfoFilePath", jobInfo.getAbsolutePath());
 
-        job.cleanupLocalJobDirIfNecessary(createTime + 999);
-        Assert.assertTrue(localJobDir.exists());
-
-        job.cleanupLocalJobDirIfNecessary(createTime + 1000);
+        job.cleanupLocalJobDirIfNecessary(createTime);
         Assert.assertFalse(localJobDir.exists());
     }
 


### PR DESCRIPTION
### 这个 PR 解决了什么问题？

Issue Number: none

Related PR: #66

Problem Summary:

#66 已为 local snapshot 增加有界读取、压缩和 reader pin，但 backup staging 目录仍缺少完整且统一的生命周期管理：checkpoint 重放可能重新创建目录，完成、取消、过期、淘汰和异常退出后的目录清理分散，删除失败或 FE 退出还可能留下孤儿目录。

本 PR 将目录删除统一收敛到 `BackupHandler`，状态机和查询 RPC 只负责业务状态与 reader pin，不直接承担目录删除 IO。

### 修改内容

#### 已知 job 的周期清理

BackupHandler 每轮 daemon 在当前 job 执行后处理：

1. remote backup 进入 `FINISHED` 或 `CANCELLED` 后立即清理，不等待 timeout；
2. local backup 进入 `CANCELLED` 后立即清理；
3. local backup 进入 `FINISHED` 后，在达到 `createTime + timeoutMs` 时清理；
4. 被 `max_backup_restore_job_num_per_db` 淘汰的终态 job 进入运行时待清理队列，有 reader 或删除失败时在后续周期重试。

这些清理仍随 BackupHandler 的正常周期执行，约每 3 秒检查一次。

#### reader 释放不执行删除 IO

`getSnapshot` reader 只在 `localJobDirLock` 下维护引用计数。清理遇到 reader 时返回并由后续周期重试；最后一个 reader 释放时只递减引用计数，不再递归删除目录。实际删除由后续 BackupHandler 周期执行，因此不会在 RPC reader 线程执行目录 IO。

#### 孤儿目录低频扫描

扫描当前 FE 的 `tmp_dir/backup/repo__*/`，只删除没有被历史 job 或待清理 job 引用、且目录 mtime 超过宽限期的普通目录。

- `backup_orphan_dir_keep_max_second`：删除宽限期，默认 2 天；非正数禁用孤儿删除；
- `backup_orphan_dir_cleanup_interval_second`：全量扫描周期，默认 3600 秒；非正数禁用扫描；支持动态修改。

FE 启动、重启或角色切换后的第一个 BackupHandler 周期立即扫描一次，之后按独立周期扫描。系统时间回拨时允许立即扫描，不会长期停扫。已知 job 的常规清理不受该扫描周期影响。

#### checkpoint 与多 FE

普通 follower replay `SAVE_META` 时会在本机写 staging 文件，BackupHandler 在所有类型 FE 上运行并负责本机目录清理。checkpoint handler 只重建生成 image 所需的内存状态，checkpoint 线程 replay `SAVE_META` 时不再落盘，也不会把淘汰 job 加入运行时待清理队列。

### 兼容性与范围

- 不修改 image、journal、Thrift、BackupJob 持久化字段或 staging 路径格式；
- 不修改 `PENDING -> SNAPSHOTING`、BarrierLog/commit sequence、`UPLOAD_INFO` 重试、Restore 状态机及 EditLog 时序；
- 保持 #66 的大文件读取、压缩上限和 reader pin 设计；
- 新配置仅控制 orphan 全量扫描频率，支持动态修改，无需重启 FE；
- 不修改 `localSnapshots` 的索引方式。它仍以裸 label 为 key，本 PR 不宣称实现按数据库隔离 snapshot。

说明：历史提交 `20091d211b` 的标题和提交说明曾写入 “scope snapshots by database”，该表述不准确，当前实现并未将 snapshot key 改为 `(dbId, label)`。该问题是已有行为，并非 #66/#67 引入，也不属于本 PR 的 staging 目录清理范围。

### 可能存在的问题

1. 淘汰待清理队列不持久化。FE 在删除前退出时，目录会转为孤儿，并在重启后的宽限期与扫描周期到达后回收。
2. 孤儿判断依赖目录 mtime 和 FE 本机时钟。默认 2 天宽限期降低误删风险；仍被 job 引用的目录不会仅因 mtime 被删除。
3. 递归删除仍在 BackupHandler daemon 中同步执行，单个超大目录可能延长当前周期；全量 orphan 枚举已降频为默认每小时一次。
4. `localSnapshots` 仍为 `Map<String, BackupJob>`，不同数据库使用相同 label 时可能覆盖、删除或返回另一数据库的 snapshot。这是已有问题，本 PR 不处理。
5. #66 之前已有的 label 物理路径碰撞、可变时区路径、`UPLOAD_INFO` failover 和超大压缩响应内存峰值不属于本 PR 的目录清理目标。

### Release note

None

### Check List（For Author）

- Test：Unit Test
    - branch-3.1：`./run-fe-ut.sh --run org.apache.doris.backup.BackupJobTest,org.apache.doris.common.GZIPUtilsTest`
    - `BackupJobTest`：22 tests，0 failures，0 errors
    - `GZIPUtilsTest`：1 test，0 failures，0 errors
    - FE 16-module reactor：`BUILD SUCCESS`
    - Maven Checkstyle：通过
    - `git diff --check`：通过
    - 覆盖 reader 释放不删除、后续 daemon 重试、淘汰 pending 重试、remote/local 生命周期、checkpoint、孤儿引用与宽限期、symlink 保护、禁用配置和独立扫描周期。
- Behavior changed: Yes
    - remote 终态 staging 在同一轮 daemon 清理；
    - local `CANCELLED` staging 在下一轮 daemon 清理；
    - local `FINISHED` staging 在过期或淘汰后清理；
    - snapshot RPC reader 不执行目录删除；
    - orphan 全量扫描默认每小时执行一次。
- Does this need documentation: No
