### PR TITLE
[improvement](be) Configure shutdown tablet sweep

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -374,6 +374,11 @@ DEFINE_mInt32(snapshot_expire_time_sec, "172800");
 // It is only a recommended value. When the disk space is insufficient,
 // the file storage period under trash dose not have to comply with this parameter.
 DEFINE_mInt32(trash_file_expire_time_sec, "0");
+// BE-only dynamic configs for shutdown tablet sweep throttling. Invalid values fall back to the
+// historical defaults at the use site because branch-3.1 validators cannot validate candidate
+// values during dynamic updates.
+DEFINE_mInt32(shutdown_tablet_sweep_round_budget, "200");
+DEFINE_mInt32(shutdown_tablet_sweep_interval_ms, "1000");
 // minimum file descriptor number
 // modify them upon necessity
 DEFINE_Int32(min_file_descriptor_number, "60000");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -374,9 +374,9 @@ DEFINE_mInt32(snapshot_expire_time_sec, "172800");
 // It is only a recommended value. When the disk space is insufficient,
 // the file storage period under trash dose not have to comply with this parameter.
 DEFINE_mInt32(trash_file_expire_time_sec, "0");
-// BE-only dynamic configs for shutdown tablet sweep throttling. Invalid values fall back to the
-// historical defaults at the use site because branch-3.1 validators cannot validate candidate
-// values during dynamic updates.
+// BE-only dynamic configs for shutdown tablet sweep throttling. The round budget defaults to 200
+// with a valid range of [1, 10000], and the interval defaults to 1000 ms with a valid range of
+// [0, 10000]. Values outside these ranges fall back to the historical defaults at the use site.
 DEFINE_mInt32(shutdown_tablet_sweep_round_budget, "200");
 DEFINE_mInt32(shutdown_tablet_sweep_interval_ms, "1000");
 // minimum file descriptor number

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -424,12 +424,12 @@ DECLARE_mInt32(snapshot_expire_time_sec);
 // It is only a recommended value. When the disk space is insufficient,
 // the file storage period under trash dose not have to comply with this parameter.
 DECLARE_mInt32(trash_file_expire_time_sec);
-// BE-only dynamic config. It limits how many shutdown tablets can be moved to trash in one
-// sweep round. Values less than 1 fall back to the historical limit of 200 at the use site.
+// BE-only dynamic config. Default is 200 and the valid range is [1, 10000]. Values outside the
+// valid range fall back to the historical limit of 200 at the use site.
 DECLARE_mInt32(shutdown_tablet_sweep_round_budget);
-// BE-only dynamic config. It controls the sleep interval in milliseconds between shutdown
-// tablet sweep rounds. A value of 0 skips the inter-round wait. Negative values fall back to the
-// historical 1000 ms interval at the use site.
+// BE-only dynamic config. Default is 1000 ms and the valid range is [0, 10000]. A value of 0
+// skips the inter-round wait. Values outside the valid range fall back to the historical 1000 ms
+// interval at the use site.
 DECLARE_mInt32(shutdown_tablet_sweep_interval_ms);
 // minimum file descriptor number
 // modify them upon necessity

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -424,6 +424,13 @@ DECLARE_mInt32(snapshot_expire_time_sec);
 // It is only a recommended value. When the disk space is insufficient,
 // the file storage period under trash dose not have to comply with this parameter.
 DECLARE_mInt32(trash_file_expire_time_sec);
+// BE-only dynamic config. It limits how many shutdown tablets can be moved to trash in one
+// sweep round. Values less than 1 fall back to the historical limit of 200 at the use site.
+DECLARE_mInt32(shutdown_tablet_sweep_round_budget);
+// BE-only dynamic config. It controls the sleep interval in milliseconds between shutdown
+// tablet sweep rounds. A value of 0 skips the inter-round wait. Negative values fall back to the
+// historical 1000 ms interval at the use site.
+DECLARE_mInt32(shutdown_tablet_sweep_interval_ms);
 // minimum file descriptor number
 // modify them upon necessity
 DECLARE_Int32(min_file_descriptor_number);

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -90,41 +90,47 @@ constexpr int kShutdownTabletScanChunk = 200;
 // These defaults preserve the historical shutdown sweep behavior when the dynamic config is invalid.
 constexpr int kDefaultShutdownTabletSweepRoundBudget = 200;
 constexpr int kDefaultShutdownTabletSweepIntervalMs = 1000;
+constexpr int kMaxShutdownTabletSweepRoundBudget = 10000;
+constexpr int kMaxShutdownTabletSweepIntervalMs = 10000;
 
 // Read the round budget locally so invalid dynamic values cannot stall the shutdown sweep.
 int get_effective_shutdown_tablet_sweep_round_budget() {
     const int configured_budget = config::shutdown_tablet_sweep_round_budget;
-    if (configured_budget > 0) {
+    if (configured_budget >= 1 && configured_budget <= kMaxShutdownTabletSweepRoundBudget) {
         return configured_budget;
     }
     LOG_EVERY_N(WARNING, 100) << "invalid shutdown_tablet_sweep_round_budget=" << configured_budget
+                              << ", valid range=[1, " << kMaxShutdownTabletSweepRoundBudget << "]"
                               << ", fallback to default=" << kDefaultShutdownTabletSweepRoundBudget;
     return kDefaultShutdownTabletSweepRoundBudget;
 }
 
-// Read the interval locally so negative dynamic values cannot provide an invalid wait duration.
+// Read the interval locally so invalid dynamic values cannot provide an unexpected wait duration.
 int get_effective_shutdown_tablet_sweep_interval_ms() {
     const int configured_interval_ms = config::shutdown_tablet_sweep_interval_ms;
-    if (configured_interval_ms >= 0) {
+    if (configured_interval_ms >= 0 &&
+        configured_interval_ms <= kMaxShutdownTabletSweepIntervalMs) {
         return configured_interval_ms;
     }
     LOG_EVERY_N(WARNING, 100) << "invalid shutdown_tablet_sweep_interval_ms="
-                              << configured_interval_ms
+                              << configured_interval_ms << ", valid range=[0, "
+                              << kMaxShutdownTabletSweepIntervalMs << "]"
                               << ", fallback to default=" << kDefaultShutdownTabletSweepIntervalMs;
     return kDefaultShutdownTabletSweepIntervalMs;
 }
 } // namespace
 
 bvar::Adder<int64_t> g_tablet_meta_schema_columns_count("tablet_meta_schema_columns_count");
-// These metrics expose shutdown tablet sweep backlog, outcomes, and timing.
+// These metrics expose shutdown tablet sweep backlog, resolved outcomes, and timing.
 bvar::Adder<int64_t> g_shutdown_tablet_cleanup_backlog("shutdown_tablet_cleanup_backlog");
-bvar::Status<int64_t> g_shutdown_tablet_last_round_moved("shutdown_tablet_last_round_moved", 0);
+bvar::Status<int64_t> g_shutdown_tablet_last_round_resolved("shutdown_tablet_last_round_resolved",
+                                                            0);
 bvar::Status<int64_t> g_shutdown_tablet_last_round_move_failed_attempts(
         "shutdown_tablet_last_round_move_failed_attempts", 0);
 bvar::Status<int64_t> g_shutdown_tablet_last_round_ms("shutdown_tablet_last_round_ms", 0);
 bvar::Status<int64_t> g_trash_sweep_stale_rowset_phase_ms("trash_sweep_stale_rowset_phase_ms", 0);
 bvar::Status<int64_t> g_shutdown_tablet_last_sweep_ms("shutdown_tablet_last_sweep_ms", 0);
-bvar::Adder<int64_t> g_shutdown_tablet_sweep_moved_total("shutdown_tablet_sweep_moved_total");
+bvar::Adder<int64_t> g_shutdown_tablet_sweep_resolved_total("shutdown_tablet_sweep_resolved_total");
 bvar::Adder<int64_t> g_shutdown_tablet_sweep_move_failed_attempts_total(
         "shutdown_tablet_sweep_move_failed_attempts_total");
 
@@ -1273,7 +1279,7 @@ TabletManager::RoundResult TabletManager::_delete_shutdown_tablets_one_round(
         for (const auto& tablet : fetch_result.tablets) {
             if (move_tablet(tablet)) {
                 --budget;
-                ++result.moved_count;
+                ++result.resolved_count;
                 // Decrement the pending backlog after the shutdown entry is fully resolved.
                 _adjust_shutdown_tablet_backlog(-1);
             } else {
@@ -1313,10 +1319,10 @@ Status TabletManager::_sweep_shutdown_tablets(
                 last_it, failed_tablets, move_tablet,
                 get_effective_shutdown_tablet_sweep_round_budget(), kShutdownTabletFetchChunk,
                 kShutdownTabletScanChunk);
-        g_shutdown_tablet_last_round_moved.set_value(round_result.moved_count);
+        g_shutdown_tablet_last_round_resolved.set_value(round_result.resolved_count);
         g_shutdown_tablet_last_round_move_failed_attempts.set_value(round_result.failed_count);
         g_shutdown_tablet_last_round_ms.set_value(round_result.elapsed_ms);
-        g_shutdown_tablet_sweep_moved_total << round_result.moved_count;
+        g_shutdown_tablet_sweep_resolved_total << round_result.resolved_count;
         g_shutdown_tablet_sweep_move_failed_attempts_total << round_result.failed_count;
         if (!round_result.need_continue) {
             break;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -25,13 +25,14 @@
 #include <gen_cpp/Types_types.h>
 #include <gen_cpp/olap_file.pb.h>
 #include <re2/re2.h>
-#include <unistd.h>
 
 #include <algorithm>
+#include <chrono>
 #include <list>
 #include <mutex>
 #include <ostream>
 #include <string_view>
+#include <thread>
 
 #include "bvar/bvar.h"
 #include "common/compiler_util.h" // IWYU pragma: keep
@@ -81,7 +82,51 @@ using std::vector;
 namespace doris {
 using namespace ErrorCode;
 
+namespace {
+// These constants bound each fetch and scan pass while the round budget is read dynamically.
+constexpr int kShutdownTabletFetchChunk = 200;
+constexpr int kShutdownTabletScanChunk = 200;
+
+// These defaults preserve the historical shutdown sweep behavior when the dynamic config is invalid.
+constexpr int kDefaultShutdownTabletSweepRoundBudget = 200;
+constexpr int kDefaultShutdownTabletSweepIntervalMs = 1000;
+
+// Read the round budget locally so invalid dynamic values cannot stall the shutdown sweep.
+int get_effective_shutdown_tablet_sweep_round_budget() {
+    const int configured_budget = config::shutdown_tablet_sweep_round_budget;
+    if (configured_budget > 0) {
+        return configured_budget;
+    }
+    LOG_EVERY_N(WARNING, 100) << "invalid shutdown_tablet_sweep_round_budget=" << configured_budget
+                              << ", fallback to default=" << kDefaultShutdownTabletSweepRoundBudget;
+    return kDefaultShutdownTabletSweepRoundBudget;
+}
+
+// Read the interval locally so negative dynamic values cannot provide an invalid wait duration.
+int get_effective_shutdown_tablet_sweep_interval_ms() {
+    const int configured_interval_ms = config::shutdown_tablet_sweep_interval_ms;
+    if (configured_interval_ms >= 0) {
+        return configured_interval_ms;
+    }
+    LOG_EVERY_N(WARNING, 100) << "invalid shutdown_tablet_sweep_interval_ms="
+                              << configured_interval_ms
+                              << ", fallback to default=" << kDefaultShutdownTabletSweepIntervalMs;
+    return kDefaultShutdownTabletSweepIntervalMs;
+}
+} // namespace
+
 bvar::Adder<int64_t> g_tablet_meta_schema_columns_count("tablet_meta_schema_columns_count");
+// These metrics expose shutdown tablet sweep backlog, outcomes, and timing.
+bvar::Adder<int64_t> g_shutdown_tablet_cleanup_backlog("shutdown_tablet_cleanup_backlog");
+bvar::Status<int64_t> g_shutdown_tablet_last_round_moved("shutdown_tablet_last_round_moved", 0);
+bvar::Status<int64_t> g_shutdown_tablet_last_round_move_failed_attempts(
+        "shutdown_tablet_last_round_move_failed_attempts", 0);
+bvar::Status<int64_t> g_shutdown_tablet_last_round_ms("shutdown_tablet_last_round_ms", 0);
+bvar::Status<int64_t> g_trash_sweep_stale_rowset_phase_ms("trash_sweep_stale_rowset_phase_ms", 0);
+bvar::Status<int64_t> g_shutdown_tablet_last_sweep_ms("shutdown_tablet_last_sweep_ms", 0);
+bvar::Adder<int64_t> g_shutdown_tablet_sweep_moved_total("shutdown_tablet_sweep_moved_total");
+bvar::Adder<int64_t> g_shutdown_tablet_sweep_move_failed_attempts_total(
+        "shutdown_tablet_sweep_move_failed_attempts_total");
 
 TabletManager::TabletManager(StorageEngine& engine, int32_t tablet_map_lock_shard_size)
         : _engine(engine),
@@ -93,6 +138,26 @@ TabletManager::TabletManager(StorageEngine& engine, int32_t tablet_map_lock_shar
 }
 
 TabletManager::~TabletManager() = default;
+
+void TabletManager::_enqueue_shutdown_tablet(const TabletSharedPtr& tablet) {
+    std::lock_guard<std::shared_mutex> shutdown_tablets_wrlock(_shutdown_tablets_lock);
+    _shutdown_tablets.push_back(tablet);
+    _adjust_shutdown_tablet_backlog(1);
+}
+
+void TabletManager::_adjust_shutdown_tablet_backlog(int64_t delta) {
+    g_shutdown_tablet_cleanup_backlog << delta;
+}
+
+#ifdef BE_TEST
+int64_t TabletManager::_shutdown_tablet_backlog_value() const {
+    return g_shutdown_tablet_cleanup_backlog.get_value();
+}
+
+int64_t TabletManager::_shutdown_tablet_last_sweep_ms_value() const {
+    return g_shutdown_tablet_last_sweep_ms.get_value();
+}
+#endif
 
 Status TabletManager::_add_tablet_unlocked(TTabletId tablet_id, const TabletSharedPtr& tablet,
                                            bool update_meta, bool force, RuntimeProfile* profile) {
@@ -178,10 +243,7 @@ Status TabletManager::_add_tablet_unlocked(TTabletId tablet_id, const TabletShar
         tablet->save_meta();
         COUNTER_UPDATE(ADD_CHILD_TIMER(profile, "SaveMeta", "AddTablet"),
                        static_cast<int64_t>(watch.reset()));
-        {
-            std::lock_guard<std::shared_mutex> shutdown_tablets_wrlock(_shutdown_tablets_lock);
-            _shutdown_tablets.push_back(tablet);
-        }
+        _enqueue_shutdown_tablet(tablet);
 
         res = Status::Error<ENGINE_INSERT_OLD_TABLET>(
                 "set tablet to shutdown state. tablet_id={}, tablet_path={}", tablet->tablet_id(),
@@ -581,10 +643,7 @@ Status TabletManager::_drop_tablet(TTabletId tablet_id, TReplicaId replica_id, b
                 RETURN_IF_ERROR(to_drop_tablet->remove_all_remote_rowsets());
             }
             to_drop_tablet->save_meta();
-            {
-                std::lock_guard<std::shared_mutex> wrdlock(_shutdown_tablets_lock);
-                _shutdown_tablets.push_back(to_drop_tablet);
-            }
+            _enqueue_shutdown_tablet(to_drop_tablet);
         }
     }
 
@@ -927,10 +986,7 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
     }
 
     if (tablet->tablet_meta()->tablet_state() == TABLET_SHUTDOWN) {
-        {
-            std::lock_guard<std::shared_mutex> shutdown_tablets_wrlock(_shutdown_tablets_lock);
-            _shutdown_tablets.push_back(tablet);
-        }
+        _enqueue_shutdown_tablet(tablet);
         return Status::Error<TABLE_ALREADY_DELETED_ERROR>(
                 "fail to load tablet because it is to be deleted. tablet_id={}, schema_hash={}, "
                 "path={}",
@@ -1126,8 +1182,10 @@ Status TabletManager::start_trash_sweep() {
         return Status::OK();
     }
 
+    MonotonicStopWatch stale_rowset_watch(true);
     for_each_tablet([](const TabletSharedPtr& tablet) { tablet->delete_expired_stale_rowset(); },
                     filter_all_tablets);
+    g_trash_sweep_stale_rowset_phase_ms.set_value(stale_rowset_watch.elapsed_time_milliseconds());
 
     if (config::enable_check_agg_and_remove_pre_rowsets_delete_bitmap) {
         int64_t max_useless_rowset_count = 0;
@@ -1162,65 +1220,115 @@ Status TabletManager::start_trash_sweep() {
                   << ", tablet_id=" << tablet_id_with_max_useless_rowset_version_count;
     }
 
-    std::list<TabletSharedPtr>::iterator last_it;
+    // Execute the shutdown tablet sweep with round-based throttling.
+    return _sweep_shutdown_tablets(
+            [this](const TabletSharedPtr& tablet) { return _move_tablet_to_trash(tablet); },
+            [](int interval_ms) {
+#ifndef BE_TEST
+                std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms));
+#else
+                static_cast<void>(interval_ms);
+#endif
+            });
+}
+
+TabletManager::FetchResult TabletManager::_fetch_shutdown_tablets(ShutdownTabletIter& last_it,
+                                                                  int max_to_fetch,
+                                                                  int scan_chunk) {
+    DCHECK_GT(max_to_fetch, 0);
+    DCHECK_GT(scan_chunk, 0);
+
+    FetchResult result;
+    std::lock_guard<std::shared_mutex> wrdlock(_shutdown_tablets_lock);
+    while (last_it != _shutdown_tablets.end() && result.scanned_count < scan_chunk &&
+           static_cast<int>(result.tablets.size()) < max_to_fetch) {
+        result.scanned_count++;
+        // Skip tablets that are still referenced by other threads in the current pass.
+        if (last_it->use_count() > 1) {
+            ++last_it;
+        } else {
+            result.tablets.push_back(*last_it);
+            last_it = _shutdown_tablets.erase(last_it);
+        }
+    }
+    result.reached_end = (last_it == _shutdown_tablets.end());
+    return result;
+}
+
+TabletManager::RoundResult TabletManager::_delete_shutdown_tablets_one_round(
+        ShutdownTabletIter& last_it, std::list<TabletSharedPtr>& failed_tablets,
+        const std::function<bool(const TabletSharedPtr&)>& move_tablet, int round_budget,
+        int fetch_chunk, int scan_chunk) {
+    DCHECK_GT(round_budget, 0);
+    DCHECK_GT(fetch_chunk, 0);
+    DCHECK_GT(scan_chunk, 0);
+
+    MonotonicStopWatch round_watch(true);
+    RoundResult result;
+    int budget = round_budget;
+    for (;;) {
+        const int max_to_fetch = std::min(budget, fetch_chunk);
+        DCHECK_GT(max_to_fetch, 0);
+        auto fetch_result = _fetch_shutdown_tablets(last_it, max_to_fetch, scan_chunk);
+        for (const auto& tablet : fetch_result.tablets) {
+            if (move_tablet(tablet)) {
+                --budget;
+                ++result.moved_count;
+                // Decrement the pending backlog after the shutdown entry is fully resolved.
+                _adjust_shutdown_tablet_backlog(-1);
+            } else {
+                failed_tablets.push_back(tablet);
+                ++result.failed_count;
+            }
+        }
+        if (fetch_result.reached_end) {
+            result.elapsed_ms = round_watch.elapsed_time_milliseconds();
+            return result;
+        }
+        if (budget <= 0) {
+            result.need_continue = true;
+            result.elapsed_ms = round_watch.elapsed_time_milliseconds();
+            return result;
+        }
+    }
+}
+
+Status TabletManager::_sweep_shutdown_tablets(
+        const std::function<bool(const TabletSharedPtr&)>& move_tablet,
+        const std::function<void(int)>& wait_next_round) {
+    MonotonicStopWatch sweep_watch(true);
+    ShutdownTabletIter last_it;
     {
         std::shared_lock rdlock(_shutdown_tablets_lock);
         last_it = _shutdown_tablets.begin();
         if (last_it == _shutdown_tablets.end()) {
+            g_shutdown_tablet_last_sweep_ms.set_value(0);
             return Status::OK();
         }
     }
 
-    auto get_batch_tablets = [this, &last_it](int limit) {
-        std::vector<TabletSharedPtr> batch_tablets;
-        std::lock_guard<std::shared_mutex> wrdlock(_shutdown_tablets_lock);
-        while (last_it != _shutdown_tablets.end() && batch_tablets.size() < limit) {
-            // it means current tablet is referenced by other thread
-            if (last_it->use_count() > 1) {
-                last_it++;
-            } else {
-                batch_tablets.push_back(*last_it);
-                last_it = _shutdown_tablets.erase(last_it);
-            }
-        }
-
-        return batch_tablets;
-    };
-
     std::list<TabletSharedPtr> failed_tablets;
-    // return true if need continue delete
-    auto delete_one_batch = [this, get_batch_tablets, &failed_tablets]() -> bool {
-        int limit = 200;
-        for (;;) {
-            auto batch_tablets = get_batch_tablets(limit);
-            for (const auto& tablet : batch_tablets) {
-                if (_move_tablet_to_trash(tablet)) {
-                    limit--;
-                } else {
-                    failed_tablets.push_back(tablet);
-                }
-            }
-            if (limit <= 0) {
-                return true;
-            }
-            if (batch_tablets.empty()) {
-                return false;
-            }
+    for (;;) {
+        auto round_result = _delete_shutdown_tablets_one_round(
+                last_it, failed_tablets, move_tablet,
+                get_effective_shutdown_tablet_sweep_round_budget(), kShutdownTabletFetchChunk,
+                kShutdownTabletScanChunk);
+        g_shutdown_tablet_last_round_moved.set_value(round_result.moved_count);
+        g_shutdown_tablet_last_round_move_failed_attempts.set_value(round_result.failed_count);
+        g_shutdown_tablet_last_round_ms.set_value(round_result.elapsed_ms);
+        g_shutdown_tablet_sweep_moved_total << round_result.moved_count;
+        g_shutdown_tablet_sweep_move_failed_attempts_total << round_result.failed_count;
+        if (!round_result.need_continue) {
+            break;
         }
-
-        return false;
-    };
-
-    while (delete_one_batch()) {
-#ifndef BE_TEST
-        sleep(1);
-#endif
+        wait_next_round(get_effective_shutdown_tablet_sweep_interval_ms());
     }
 
     if (!failed_tablets.empty()) {
         std::lock_guard<std::shared_mutex> wrlock(_shutdown_tablets_lock);
         _shutdown_tablets.splice(_shutdown_tablets.end(), failed_tablets);
     }
+    g_shutdown_tablet_last_sweep_ms.set_value(sweep_watch.elapsed_time_milliseconds());
 
     return Status::OK();
 }
@@ -1755,11 +1863,7 @@ std::set<int64_t> TabletManager::check_all_tablet_segment(bool repair) {
                 const auto& tablet = it->second;
                 static_cast<void>(tablet->set_tablet_state(TABLET_SHUTDOWN));
                 tablet->save_meta();
-                {
-                    std::lock_guard<std::shared_mutex> shutdown_tablets_wrlock(
-                            _shutdown_tablets_lock);
-                    _shutdown_tablets.push_back(tablet);
-                }
+                _enqueue_shutdown_tablet(tablet);
                 LOG(WARNING) << "There are some segments lost, set tablet to shutdown state."
                              << "tablet_id=" << tablet->tablet_id()
                              << ", tablet_path=" << tablet->tablet_path();

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -194,7 +194,7 @@ private:
     // RoundResult captures the outcome and cost of one shutdown tablet sweep round.
     struct RoundResult {
         bool need_continue = false;
-        int64_t moved_count = 0;
+        int64_t resolved_count = 0;
         int64_t failed_count = 0;
         int64_t elapsed_ms = 0;
     };

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include <functional>
+#include <list>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -182,6 +183,24 @@ public:
                                              uint64_t* max_base_rowset_delete_bitmap_score);
 
 private:
+    // FetchResult captures the current batch, whether the current pass reaches the tail,
+    // and how many shutdown entries are scanned under the lock.
+    struct FetchResult {
+        std::vector<TabletSharedPtr> tablets;
+        bool reached_end = false;
+        int scanned_count = 0;
+    };
+
+    // RoundResult captures the outcome and cost of one shutdown tablet sweep round.
+    struct RoundResult {
+        bool need_continue = false;
+        int64_t moved_count = 0;
+        int64_t failed_count = 0;
+        int64_t elapsed_ms = 0;
+    };
+
+    using ShutdownTabletIter = std::list<TabletSharedPtr>::iterator;
+
     // Add a tablet pointer to StorageEngine
     // If force, drop the existing tablet add this new one
     //
@@ -224,6 +243,32 @@ private:
     void _remove_tablet_from_partition(const TabletSharedPtr& tablet);
 
     std::shared_mutex& _get_tablets_shard_lock(TTabletId tabletId);
+
+    // Fetch a bounded batch of shutdown tablets while limiting lock hold time.
+    FetchResult _fetch_shutdown_tablets(ShutdownTabletIter& last_it, int max_to_fetch,
+                                        int scan_chunk);
+
+    // Delete one round of shutdown tablets under the configured success budget.
+    RoundResult _delete_shutdown_tablets_one_round(
+            ShutdownTabletIter& last_it, std::list<TabletSharedPtr>& failed_tablets,
+            const std::function<bool(const TabletSharedPtr&)>& move_tablet, int round_budget,
+            int fetch_chunk, int scan_chunk);
+
+    // Sweep shutdown tablets with round-based throttling and retry preservation.
+    Status _sweep_shutdown_tablets(const std::function<bool(const TabletSharedPtr&)>& move_tablet,
+                                   const std::function<void(int)>& wait_next_round);
+
+    // Add a tablet to the shutdown cleanup backlog.
+    void _enqueue_shutdown_tablet(const TabletSharedPtr& tablet);
+
+    // Adjust the shutdown backlog metric by delta for queue lifecycle changes.
+    void _adjust_shutdown_tablet_backlog(int64_t delta);
+
+#ifdef BE_TEST
+    // Read shutdown sweep metric values for test isolation.
+    int64_t _shutdown_tablet_backlog_value() const;
+    int64_t _shutdown_tablet_last_sweep_ms_value() const;
+#endif
 
     bool _move_tablet_to_trash(const TabletSharedPtr& tablet);
 

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -79,21 +79,76 @@ public:
         _data_dir = new DataDir(*k_engine, _engine_data_path, 1000000000);
         static_cast<void>(_data_dir->init());
         _tablet_mgr = k_engine->tablet_manager();
+        _shutdown_backlog_base = _tablet_mgr->_shutdown_tablet_backlog_value();
     }
 
     virtual void TearDown() {
+        if (_tablet_mgr != nullptr) {
+            _tablet_mgr->_adjust_shutdown_tablet_backlog(
+                    _shutdown_backlog_base - _tablet_mgr->_shutdown_tablet_backlog_value());
+        }
         SAFE_DELETE(_data_dir);
         EXPECT_TRUE(io::global_local_filesystem()->delete_directory(_engine_data_path).ok());
         ExecEnv::GetInstance()->set_storage_engine(nullptr);
         _tablet_mgr = nullptr;
         config::compaction_num_per_round = 1;
+        config::shutdown_tablet_sweep_round_budget = 200;
+        config::shutdown_tablet_sweep_interval_ms = 1000;
     }
+
+    // Build a shared_ptr control block without constructing a real Tablet instance.
+    // The returned pointer is only valid for ownership and use_count() assertions.
+    // Tests must never dereference the Tablet* value behind this aliasing shared_ptr.
+    TabletSharedPtr create_mock_shutdown_tablet() {
+        auto owner = std::make_shared<int>(1);
+        return TabletSharedPtr(owner, reinterpret_cast<Tablet*>(owner.get()));
+    }
+
+    // Replace the shutdown tablet queue with the provided test entries.
+    void reset_shutdown_tablets(const std::vector<TabletSharedPtr>& tablets) {
+        std::lock_guard<std::shared_mutex> wrlock(_tablet_mgr->_shutdown_tablets_lock);
+        const int64_t old_size = _tablet_mgr->_shutdown_tablets.size();
+        _tablet_mgr->_shutdown_tablets.clear();
+        for (const auto& tablet : tablets) {
+            _tablet_mgr->_shutdown_tablets.push_back(tablet);
+        }
+        // Keep the backlog metric aligned with direct queue mutations in unit tests.
+        _tablet_mgr->_adjust_shutdown_tablet_backlog(static_cast<int64_t>(tablets.size()) -
+                                                     old_size);
+    }
+
+    // Snapshot the current shutdown tablet raw pointers for order assertions.
+    std::vector<Tablet*> list_shutdown_tablet_ptrs() {
+        std::shared_lock<std::shared_mutex> rdlock(_tablet_mgr->_shutdown_tablets_lock);
+        std::vector<Tablet*> tablets;
+        tablets.reserve(_tablet_mgr->_shutdown_tablets.size());
+        for (const auto& tablet : _tablet_mgr->_shutdown_tablets) {
+            tablets.push_back(tablet.get());
+        }
+        return tablets;
+    }
+
+    // Read the current shutdown tablet count under the queue lock.
+    size_t shutdown_tablet_count() {
+        std::shared_lock<std::shared_mutex> rdlock(_tablet_mgr->_shutdown_tablets_lock);
+        return _tablet_mgr->_shutdown_tablets.size();
+    }
+
+    int64_t shutdown_tablet_backlog_value() {
+        return _tablet_mgr->_shutdown_tablet_backlog_value();
+    }
+
+    int64_t shutdown_tablet_last_sweep_ms_value() {
+        return _tablet_mgr->_shutdown_tablet_last_sweep_ms_value();
+    }
+
     StorageEngine* k_engine;
 
 private:
     DataDir* _data_dir = nullptr;
     std::string _engine_data_path;
     TabletManager* _tablet_mgr = nullptr;
+    int64_t _shutdown_backlog_base = 0;
 };
 
 TEST_F(TabletMgrTest, CreateTablet) {
@@ -263,6 +318,331 @@ TEST_F(TabletMgrTest, DropTablet) {
     EXPECT_TRUE(tablet == nullptr);
     EXPECT_TRUE(io::global_local_filesystem()->exists(tablet_path, &dir_exist).ok());
     EXPECT_FALSE(dir_exist);
+}
+
+TEST_F(TabletMgrTest, DeleteShutdownTabletsRoundRespectsBudget) {
+    struct TestCase {
+        int round_budget;
+        size_t expected_remaining;
+    };
+
+    const std::vector<TestCase> test_cases = {
+            {1, 204},
+            {199, 6},
+            {200, 5},
+            {201, 4},
+    };
+    for (const auto& test_case : test_cases) {
+        // Rebuild the shutdown queue for each budget case.
+        std::vector<TabletSharedPtr> tablets;
+        for (int i = 0; i < 205; ++i) {
+            tablets.push_back(create_mock_shutdown_tablet());
+        }
+        reset_shutdown_tablets(tablets);
+        // Drop external references so movable tablets keep use_count() == 1 in the queue.
+        tablets.clear();
+
+        TabletManager::ShutdownTabletIter last_it;
+        {
+            std::shared_lock<std::shared_mutex> rdlock(_tablet_mgr->_shutdown_tablets_lock);
+            last_it = _tablet_mgr->_shutdown_tablets.begin();
+        }
+        std::list<TabletSharedPtr> failed_tablets;
+        const auto round_result = _tablet_mgr->_delete_shutdown_tablets_one_round(
+                last_it, failed_tablets, [](const TabletSharedPtr&) { return true; },
+                test_case.round_budget, 200, 200);
+
+        EXPECT_TRUE(round_result.need_continue);
+        EXPECT_EQ(round_result.moved_count, test_case.round_budget);
+        EXPECT_EQ(round_result.failed_count, 0);
+        EXPECT_TRUE(failed_tablets.empty());
+        EXPECT_EQ(shutdown_tablet_count(), test_case.expected_remaining);
+    }
+}
+
+TEST_F(TabletMgrTest, DeleteShutdownTabletsRoundStopsAtExactQueueEnd) {
+    const int64_t backlog_base = shutdown_tablet_backlog_value();
+    std::vector<TabletSharedPtr> tablets;
+    for (int i = 0; i < 3; ++i) {
+        tablets.push_back(create_mock_shutdown_tablet());
+    }
+    reset_shutdown_tablets(tablets);
+    tablets.clear();
+
+    TabletManager::ShutdownTabletIter last_it;
+    {
+        std::shared_lock<std::shared_mutex> rdlock(_tablet_mgr->_shutdown_tablets_lock);
+        last_it = _tablet_mgr->_shutdown_tablets.begin();
+    }
+    std::list<TabletSharedPtr> failed_tablets;
+    const auto round_result = _tablet_mgr->_delete_shutdown_tablets_one_round(
+            last_it, failed_tablets, [](const TabletSharedPtr&) { return true; }, 3, 200, 200);
+
+    EXPECT_FALSE(round_result.need_continue);
+    EXPECT_EQ(round_result.moved_count, 3);
+    EXPECT_EQ(round_result.failed_count, 0);
+    EXPECT_TRUE(failed_tablets.empty());
+    EXPECT_EQ(shutdown_tablet_count(), 0);
+    EXPECT_EQ(shutdown_tablet_backlog_value(), backlog_base);
+}
+
+TEST_F(TabletMgrTest, SweepShutdownTabletsRecordsZeroDurationWhenEmpty) {
+    Status sweep_st = _tablet_mgr->_sweep_shutdown_tablets(
+            [](const TabletSharedPtr&) { return true; }, [](int) {});
+
+    EXPECT_TRUE(sweep_st.ok());
+    EXPECT_EQ(shutdown_tablet_last_sweep_ms_value(), 0);
+}
+
+TEST_F(TabletMgrTest, FetchShutdownTabletsRespectsScanChunkForReferencedTablets) {
+    // Hold extra references for the first 200 entries so the sweep must skip them.
+    std::vector<TabletSharedPtr> queue_tablets;
+    std::vector<TabletSharedPtr> referenced_tablets;
+    for (int i = 0; i < 200; ++i) {
+        auto tablet = create_mock_shutdown_tablet();
+        queue_tablets.push_back(tablet);
+        referenced_tablets.push_back(tablet);
+    }
+    queue_tablets.push_back(create_mock_shutdown_tablet());
+    Tablet* last_tablet_ptr = queue_tablets.back().get();
+    reset_shutdown_tablets(queue_tablets);
+    // Keep external references only for the entries that should be skipped by use_count().
+    queue_tablets.clear();
+
+    TabletManager::ShutdownTabletIter last_it;
+    {
+        std::shared_lock<std::shared_mutex> rdlock(_tablet_mgr->_shutdown_tablets_lock);
+        last_it = _tablet_mgr->_shutdown_tablets.begin();
+    }
+
+    auto first_fetch = _tablet_mgr->_fetch_shutdown_tablets(last_it, 1, 200);
+    EXPECT_TRUE(first_fetch.tablets.empty());
+    EXPECT_FALSE(first_fetch.reached_end);
+    EXPECT_EQ(first_fetch.scanned_count, 200);
+    EXPECT_EQ(shutdown_tablet_count(), 201);
+
+    auto second_fetch = _tablet_mgr->_fetch_shutdown_tablets(last_it, 1, 200);
+    EXPECT_EQ(second_fetch.tablets.size(), 1);
+    EXPECT_EQ(second_fetch.tablets[0].get(), last_tablet_ptr);
+    EXPECT_TRUE(second_fetch.reached_end);
+    EXPECT_EQ(second_fetch.scanned_count, 1);
+    EXPECT_EQ(shutdown_tablet_count(), 200);
+}
+
+TEST_F(TabletMgrTest, SweepShutdownTabletsRequeuesFailedTablets) {
+    // Keep the queue order unchanged when every move attempt fails.
+    std::vector<TabletSharedPtr> tablets;
+    for (int i = 0; i < 3; ++i) {
+        tablets.push_back(create_mock_shutdown_tablet());
+    }
+    std::vector<Tablet*> tablet_ptrs;
+    tablet_ptrs.reserve(tablets.size());
+    for (const auto& tablet : tablets) {
+        tablet_ptrs.push_back(tablet.get());
+    }
+    reset_shutdown_tablets(tablets);
+    const int64_t expected_backlog = shutdown_tablet_backlog_value();
+    // Drop external references so the sweep can fetch these queue entries.
+    tablets.clear();
+
+    int move_attempts = 0;
+    Status sweep_st = _tablet_mgr->_sweep_shutdown_tablets(
+            [&](const TabletSharedPtr&) {
+                ++move_attempts;
+                return false;
+            },
+            [](int) {});
+
+    EXPECT_TRUE(sweep_st.ok());
+    EXPECT_EQ(move_attempts, 3);
+    EXPECT_EQ(list_shutdown_tablet_ptrs(), tablet_ptrs);
+    EXPECT_EQ(shutdown_tablet_backlog_value(), expected_backlog);
+}
+
+TEST_F(TabletMgrTest, DeleteShutdownTabletsRoundKeepsFailuresOutOfBudget) {
+    std::vector<TabletSharedPtr> tablets;
+    for (int i = 0; i < 3; ++i) {
+        tablets.push_back(create_mock_shutdown_tablet());
+    }
+    reset_shutdown_tablets(tablets);
+    tablets.clear();
+
+    TabletManager::ShutdownTabletIter last_it;
+    {
+        std::shared_lock<std::shared_mutex> rdlock(_tablet_mgr->_shutdown_tablets_lock);
+        last_it = _tablet_mgr->_shutdown_tablets.begin();
+    }
+
+    int move_attempts = 0;
+    std::list<TabletSharedPtr> failed_tablets;
+    auto round_result = _tablet_mgr->_delete_shutdown_tablets_one_round(
+            last_it, failed_tablets,
+            [&](const TabletSharedPtr&) {
+                ++move_attempts;
+                return move_attempts != 1;
+            },
+            1, 200, 200);
+
+    EXPECT_TRUE(round_result.need_continue);
+    EXPECT_EQ(round_result.moved_count, 1);
+    EXPECT_EQ(round_result.failed_count, 1);
+    EXPECT_EQ(move_attempts, 2);
+    EXPECT_EQ(failed_tablets.size(), 1);
+    EXPECT_EQ(shutdown_tablet_count(), 1);
+}
+
+TEST_F(TabletMgrTest, SweepShutdownTabletsReloadsBudgetEachRound) {
+    // Update the config after the first round and verify the next round observes it.
+    std::vector<TabletSharedPtr> tablets;
+    for (int i = 0; i < 3; ++i) {
+        tablets.push_back(create_mock_shutdown_tablet());
+    }
+    reset_shutdown_tablets(tablets);
+    // Drop external references so the sweep can move these queue entries across rounds.
+    tablets.clear();
+
+    config::shutdown_tablet_sweep_round_budget = 1;
+    int move_attempts = 0;
+    int wait_count = 0;
+    Status sweep_st = _tablet_mgr->_sweep_shutdown_tablets(
+            [&](const TabletSharedPtr&) {
+                ++move_attempts;
+                return true;
+            },
+            [&](int) {
+                ++wait_count;
+                config::shutdown_tablet_sweep_round_budget = 10;
+            });
+
+    EXPECT_TRUE(sweep_st.ok());
+    EXPECT_EQ(move_attempts, 3);
+    EXPECT_EQ(wait_count, 1);
+    EXPECT_EQ(shutdown_tablet_count(), 0);
+}
+
+TEST_F(TabletMgrTest, ShutdownTabletSweepConfigsAcceptInvalidThenValidUpdates) {
+    Status status = config::set_config("shutdown_tablet_sweep_round_budget", "0", false, false);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(config::shutdown_tablet_sweep_round_budget, 0);
+
+    status = config::set_config("shutdown_tablet_sweep_round_budget", "17", false, false);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(config::shutdown_tablet_sweep_round_budget, 17);
+
+    status = config::set_config("shutdown_tablet_sweep_interval_ms", "-1", false, false);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(config::shutdown_tablet_sweep_interval_ms, -1);
+
+    status = config::set_config("shutdown_tablet_sweep_interval_ms", "50", false, false);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(config::shutdown_tablet_sweep_interval_ms, 50);
+}
+
+TEST_F(TabletMgrTest, SweepShutdownTabletsFallsBackForInvalidConfigs) {
+    const int64_t backlog_base = shutdown_tablet_backlog_value();
+    std::vector<TabletSharedPtr> tablets;
+    for (int i = 0; i < 201; ++i) {
+        tablets.push_back(create_mock_shutdown_tablet());
+    }
+    reset_shutdown_tablets(tablets);
+    tablets.clear();
+
+    ASSERT_TRUE(config::set_config("shutdown_tablet_sweep_round_budget", "0", false, false).ok());
+    ASSERT_TRUE(config::set_config("shutdown_tablet_sweep_interval_ms", "-1", false, false).ok());
+    int move_attempts = 0;
+    std::vector<int> wait_intervals;
+    Status sweep_st = _tablet_mgr->_sweep_shutdown_tablets(
+            [&](const TabletSharedPtr&) {
+                ++move_attempts;
+                return true;
+            },
+            [&](int interval_ms) { wait_intervals.push_back(interval_ms); });
+
+    EXPECT_TRUE(sweep_st.ok());
+    EXPECT_EQ(move_attempts, 201);
+    EXPECT_EQ(wait_intervals, std::vector<int>({1000}));
+    EXPECT_EQ(shutdown_tablet_count(), 0);
+    EXPECT_EQ(shutdown_tablet_backlog_value(), backlog_base);
+}
+
+TEST_F(TabletMgrTest, SweepShutdownTabletsReloadsIntervalEachRound) {
+    std::vector<TabletSharedPtr> tablets;
+    for (int i = 0; i < 3; ++i) {
+        tablets.push_back(create_mock_shutdown_tablet());
+    }
+    reset_shutdown_tablets(tablets);
+    tablets.clear();
+
+    config::shutdown_tablet_sweep_round_budget = 1;
+    config::shutdown_tablet_sweep_interval_ms = 10;
+    std::vector<int> wait_intervals;
+    Status sweep_st =
+            _tablet_mgr->_sweep_shutdown_tablets([](const TabletSharedPtr&) { return true; },
+                                                 [&](int interval_ms) {
+                                                     wait_intervals.push_back(interval_ms);
+                                                     config::shutdown_tablet_sweep_interval_ms = 20;
+                                                 });
+
+    EXPECT_TRUE(sweep_st.ok());
+    EXPECT_EQ(wait_intervals, std::vector<int>({10, 20}));
+    EXPECT_EQ(shutdown_tablet_count(), 0);
+}
+
+TEST_F(TabletMgrTest, SweepShutdownTabletsSupportsZeroInterval) {
+    std::vector<TabletSharedPtr> tablets;
+    for (int i = 0; i < 2; ++i) {
+        tablets.push_back(create_mock_shutdown_tablet());
+    }
+    reset_shutdown_tablets(tablets);
+    tablets.clear();
+
+    config::shutdown_tablet_sweep_round_budget = 1;
+    config::shutdown_tablet_sweep_interval_ms = 0;
+    std::vector<int> wait_intervals;
+    Status sweep_st = _tablet_mgr->_sweep_shutdown_tablets(
+            [](const TabletSharedPtr&) { return true; },
+            [&](int interval_ms) { wait_intervals.push_back(interval_ms); });
+
+    EXPECT_TRUE(sweep_st.ok());
+    EXPECT_EQ(wait_intervals, std::vector<int>({0}));
+    EXPECT_EQ(shutdown_tablet_count(), 0);
+}
+
+TEST_F(TabletMgrTest, SweepShutdownTabletsRequeuesMixedFailureAtTail) {
+    const int64_t backlog_base = shutdown_tablet_backlog_value();
+    std::vector<TabletSharedPtr> tablets;
+    for (int i = 0; i < 3; ++i) {
+        tablets.push_back(create_mock_shutdown_tablet());
+    }
+    Tablet* failed_tablet_ptr = tablets.front().get();
+    reset_shutdown_tablets(tablets);
+    tablets.clear();
+
+    config::shutdown_tablet_sweep_round_budget = 1;
+    int move_attempts = 0;
+    int wait_count = 0;
+    TabletSharedPtr referenced_tablet;
+    Tablet* referenced_tablet_ptr = nullptr;
+    Status sweep_st = _tablet_mgr->_sweep_shutdown_tablets(
+            [&](const TabletSharedPtr&) {
+                ++move_attempts;
+                return move_attempts != 1;
+            },
+            [&](int) {
+                ++wait_count;
+                if (wait_count == 1) {
+                    referenced_tablet = create_mock_shutdown_tablet();
+                    referenced_tablet_ptr = referenced_tablet.get();
+                    _tablet_mgr->_enqueue_shutdown_tablet(referenced_tablet);
+                }
+            });
+
+    EXPECT_TRUE(sweep_st.ok());
+    EXPECT_EQ(move_attempts, 3);
+    EXPECT_EQ(wait_count, 2);
+    EXPECT_EQ(list_shutdown_tablet_ptrs(),
+              std::vector<Tablet*>({referenced_tablet_ptr, failed_tablet_ptr}));
+    EXPECT_EQ(shutdown_tablet_backlog_value(), backlog_base + 2);
 }
 
 TEST_F(TabletMgrTest, GetRowsetId) {

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -353,7 +353,7 @@ TEST_F(TabletMgrTest, DeleteShutdownTabletsRoundRespectsBudget) {
                 test_case.round_budget, 200, 200);
 
         EXPECT_TRUE(round_result.need_continue);
-        EXPECT_EQ(round_result.moved_count, test_case.round_budget);
+        EXPECT_EQ(round_result.resolved_count, test_case.round_budget);
         EXPECT_EQ(round_result.failed_count, 0);
         EXPECT_TRUE(failed_tablets.empty());
         EXPECT_EQ(shutdown_tablet_count(), test_case.expected_remaining);
@@ -379,7 +379,7 @@ TEST_F(TabletMgrTest, DeleteShutdownTabletsRoundStopsAtExactQueueEnd) {
             last_it, failed_tablets, [](const TabletSharedPtr&) { return true; }, 3, 200, 200);
 
     EXPECT_FALSE(round_result.need_continue);
-    EXPECT_EQ(round_result.moved_count, 3);
+    EXPECT_EQ(round_result.resolved_count, 3);
     EXPECT_EQ(round_result.failed_count, 0);
     EXPECT_TRUE(failed_tablets.empty());
     EXPECT_EQ(shutdown_tablet_count(), 0);
@@ -484,7 +484,7 @@ TEST_F(TabletMgrTest, DeleteShutdownTabletsRoundKeepsFailuresOutOfBudget) {
             1, 200, 200);
 
     EXPECT_TRUE(round_result.need_continue);
-    EXPECT_EQ(round_result.moved_count, 1);
+    EXPECT_EQ(round_result.resolved_count, 1);
     EXPECT_EQ(round_result.failed_count, 1);
     EXPECT_EQ(move_attempts, 2);
     EXPECT_EQ(failed_tablets.size(), 1);
@@ -588,6 +588,37 @@ TEST_F(TabletMgrTest, SweepShutdownTabletsReloadsIntervalEachRound) {
     EXPECT_EQ(shutdown_tablet_count(), 0);
 }
 
+TEST_F(TabletMgrTest, SweepShutdownTabletsKeepsNewEntriesAheadOfFailedRetries) {
+    std::vector<TabletSharedPtr> tablets;
+    for (int i = 0; i < 2; ++i) {
+        tablets.push_back(create_mock_shutdown_tablet());
+    }
+    Tablet* failed_tablet_ptr = tablets[1].get();
+    TabletSharedPtr referenced_new_tablet = create_mock_shutdown_tablet();
+    Tablet* new_tablet_ptr = referenced_new_tablet.get();
+    reset_shutdown_tablets(tablets);
+    tablets.clear();
+
+    config::shutdown_tablet_sweep_round_budget = 1;
+    int wait_count = 0;
+    int move_attempts = 0;
+    Status sweep_st = _tablet_mgr->_sweep_shutdown_tablets(
+            [&](const TabletSharedPtr&) {
+                ++move_attempts;
+                return move_attempts == 1;
+            },
+            [&](int) {
+                ++wait_count;
+                _tablet_mgr->_enqueue_shutdown_tablet(referenced_new_tablet);
+            });
+
+    EXPECT_TRUE(sweep_st.ok());
+    EXPECT_EQ(wait_count, 1);
+    EXPECT_EQ(move_attempts, 2);
+    EXPECT_EQ(list_shutdown_tablet_ptrs(),
+              std::vector<Tablet*>({new_tablet_ptr, failed_tablet_ptr}));
+}
+
 TEST_F(TabletMgrTest, SweepShutdownTabletsSupportsZeroInterval) {
     std::vector<TabletSharedPtr> tablets;
     for (int i = 0; i < 2; ++i) {
@@ -605,6 +636,62 @@ TEST_F(TabletMgrTest, SweepShutdownTabletsSupportsZeroInterval) {
 
     EXPECT_TRUE(sweep_st.ok());
     EXPECT_EQ(wait_intervals, std::vector<int>({0}));
+    EXPECT_EQ(shutdown_tablet_count(), 0);
+}
+
+TEST_F(TabletMgrTest, SweepShutdownTabletsFallsBackForConfigsAboveMaxAndRecovers) {
+    std::vector<TabletSharedPtr> tablets;
+    for (int i = 0; i < 202; ++i) {
+        tablets.push_back(create_mock_shutdown_tablet());
+    }
+    reset_shutdown_tablets(tablets);
+    tablets.clear();
+
+    config::shutdown_tablet_sweep_round_budget = 10001;
+    config::shutdown_tablet_sweep_interval_ms = 10001;
+    int move_attempts = 0;
+    std::vector<int> wait_intervals;
+    Status sweep_st = _tablet_mgr->_sweep_shutdown_tablets(
+            [&](const TabletSharedPtr&) {
+                ++move_attempts;
+                return true;
+            },
+            [&](int interval_ms) {
+                wait_intervals.push_back(interval_ms);
+                if (wait_intervals.size() == 1) {
+                    config::shutdown_tablet_sweep_round_budget = 1;
+                    config::shutdown_tablet_sweep_interval_ms = 7;
+                }
+            });
+
+    EXPECT_TRUE(sweep_st.ok());
+    EXPECT_EQ(move_attempts, 202);
+    EXPECT_EQ(wait_intervals, std::vector<int>({1000, 7}));
+    EXPECT_EQ(shutdown_tablet_count(), 0);
+}
+
+TEST_F(TabletMgrTest, SweepShutdownTabletsAcceptsUpperBoundConfigs) {
+    std::vector<TabletSharedPtr> tablets;
+    for (int i = 0; i < 10001; ++i) {
+        tablets.push_back(create_mock_shutdown_tablet());
+    }
+    reset_shutdown_tablets(tablets);
+    tablets.clear();
+
+    config::shutdown_tablet_sweep_round_budget = 10000;
+    config::shutdown_tablet_sweep_interval_ms = 10000;
+    int move_attempts = 0;
+    std::vector<int> wait_intervals;
+    Status sweep_st = _tablet_mgr->_sweep_shutdown_tablets(
+            [&](const TabletSharedPtr&) {
+                ++move_attempts;
+                return true;
+            },
+            [&](int interval_ms) { wait_intervals.push_back(interval_ms); });
+
+    EXPECT_TRUE(sweep_st.ok());
+    EXPECT_EQ(move_attempts, 10001);
+    EXPECT_EQ(wait_intervals, std::vector<int>({10000}));
     EXPECT_EQ(shutdown_tablet_count(), 0);
 }
 


### PR DESCRIPTION
## Summary

This PR makes the BE shutdown tablet sweep configurable and easier to observe while keeping the existing retry semantics intact.

## What changed

- add two dynamic BE configs:
  - `shutdown_tablet_sweep_round_budget`: caps the number of tablets successfully moved to trash in one sweep round
  - `shutdown_tablet_sweep_interval_ms`: controls the wait interval between sweep rounds (`0` skips the inter-round wait)
- split the shutdown sweep into bounded rounds with:
  - fetch chunk limit
  - scan chunk limit
  - per-round success budget
- keep failure handling compatible with the previous behavior:
  - failed tablets do not consume budget
  - failed tablets are re-queued to the tail for later retry
- add baseline shutdown sweep observability for backlog, round outcomes, and timing
- add BE unit tests for budget boundaries, referenced tablets, failure requeue behavior, and dynamic budget reload

## Core implementation

### 1. Two-phase trash sweep entry

`TabletManager::start_trash_sweep()` still remains the entry point, but the work is now separated into two phases:

- stale rowset cleanup for all tablets
- shutdown tablet cleanup for `_shutdown_tablets`

The stale rowset phase keeps the existing behavior and now records its elapsed time independently, so it is easier to tell whether a long trash sweep is dominated by stale-rowset cleanup or by shutdown-tablet cleanup.

### 2. Round-based shutdown tablet cleanup

The shutdown tablet phase is moved into `_sweep_shutdown_tablets()`, which repeatedly executes `_delete_shutdown_tablets_one_round()`.

Each round re-reads the dynamic configs before continuing, so runtime config updates take effect on the next round without restarting BE.

The round logic is bounded by three limits:

- `kShutdownTabletScanChunk`: limits how many shutdown-tablet list entries are scanned while holding `_shutdown_tablets_lock`
- `kShutdownTabletFetchChunk`: limits how many tablets are fetched into one processing batch
- `shutdown_tablet_sweep_round_budget`: limits how many tablets can be successfully moved to trash in one round

This prevents a single sweep from holding `_shutdown_tablets_lock` for too long when many tablets are still referenced by other threads.

### 3. Fetch and round result helpers

The implementation introduces small internal helpers to make the sweep semantics explicit:

- `FetchResult` returns:
  - fetched tablets
  - whether the current pass has reached the end of the shutdown list
  - scanned count for the current locked scan
- `RoundResult` returns:
  - whether another round is needed
  - moved count
  - failed count
  - elapsed milliseconds

This keeps the production logic easier to reason about and also makes the BE unit tests deterministic.

### 4. Success-only budget consumption

The round budget is consumed only when `_move_tablet_to_trash()` reports the entry resolved.

That means:

- a failed tablet does not reduce the remaining round budget
- the round may continue scanning and processing more tablets until the success budget is exhausted or the current pass reaches the end

This preserves the intended semantics of "at most N successful trash moves per round" instead of "at most N attempts per round".

### 5. Retry preservation and queue order

If moving a tablet to trash fails, the tablet is placed into a local `failed_tablets` list for the current sweep and is spliced back to the tail of `_shutdown_tablets` after the sweep finishes.

This keeps the old retry behavior intact:

- failed tablets are not dropped
- failed tablets stay retryable in later sweeps
- already queued but unprocessed tablets keep their relative order in the current pass

### 6. Feature-local safety fallback

This PR intentionally does not change the generic config validator mechanism. To keep the change scoped to shutdown sweep behavior, invalid runtime values are handled locally in the shutdown sweep path:

- non-positive `shutdown_tablet_sweep_round_budget` falls back to the historical default `200`
- `shutdown_tablet_sweep_interval_ms=0` intentionally skips the inter-round wait
- negative `shutdown_tablet_sweep_interval_ms` falls back to the historical default `1000`

This avoids turning the PR into a generic config-infrastructure change while still preventing invalid runtime values from breaking the shutdown sweep loop.

### 7. Backlog metric semantics

The shutdown backlog metric is implemented as a pending counter rather than a size snapshot.

A shutdown tablet increments the counter when it enters the shutdown cleanup flow and decrements it when `_move_tablet_to_trash()` reports the entry fully resolved. This includes a successful move to trash and intentional skip paths where no move is needed. Failed moves and queue reordering do not rewrite the counter.

This makes the metric represent "shutdown tablets still waiting for cleanup resolution" instead of a transient list-size sample.

## Validation

### Local

- static code review
- `./build-support/clang-format.sh`
- `git diff --check`

### Remote

Validated on `wzh90` with the build under `/home/wzh/hdd-data/hydcp/hy-doris`:

- restarted BE successfully and confirmed the new binary is running
- verified FE/BE health through `172.16.0.90`
- verified the new configs are visible via BE HTTP API
- verified dynamic config update and restore:
  - `shutdown_tablet_sweep_round_budget`: `200 -> 3 -> 200`
  - `shutdown_tablet_sweep_interval_ms`: `1000 -> 5 -> 1000`
- verified shutdown sweep metrics are exposed on `http://172.16.0.90:8064/vars`

## Notes

- This PR keeps the change scoped to the shutdown tablet sweep path and does not change the generic config validator mechanism.
- FE HTTP APIs may require authentication; BE config verification was performed through the BE HTTP endpoint and FE MySQL port.
