### PR TITLE
[fix](fe) Preserve delete fallback failure cause

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
@@ -168,11 +168,12 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
             }
         } catch (Exception e) {
             try {
+                // Fall back to the write-based delete path when predicate delete validation fails.
                 new DeleteFromUsingCommand(nameParts, tableAlias, isTempPart, partitions,
                         logicalQuery, Optional.empty()).run(ctx, executor);
                 return;
             } catch (Exception e2) {
-                throw e;
+                throw buildDeleteFallbackException(e, e2);
             }
         }
 
@@ -226,6 +227,22 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
         } catch (Exception e) {
             throw new AnalysisException("set session variable by delete from command failed", e);
         }
+    }
+
+    // Preserve both the initial predicate-check failure and the fallback execution failure for diagnosis.
+    static AnalysisException buildDeleteFallbackException(Exception initialException, Exception fallbackException) {
+        String primaryMessage = fallbackException.getMessage() == null
+                ? fallbackException.toString()
+                : fallbackException.getMessage();
+        String initialMessage = initialException.getMessage() == null
+                ? initialException.toString()
+                : initialException.getMessage();
+        AnalysisException mergedException = new AnalysisException(
+                "Delete failed with 2 causes. Primary cause: " + primaryMessage
+                        + ". Initial predicate-check failure: " + initialMessage + ".",
+                fallbackException);
+        mergedException.addSuppressed(initialException);
+        return mergedException;
     }
 
     private void checkColumn(Set<String> tableColumns, SlotReference slotReference, OlapTable table) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
@@ -231,12 +231,11 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
 
     // Preserve both the initial predicate-check failure and the fallback execution failure for diagnosis.
     static AnalysisException buildDeleteFallbackException(Exception initialException, Exception fallbackException) {
-        String primaryMessage = fallbackException.getMessage() == null
-                ? fallbackException.toString()
-                : fallbackException.getMessage();
-        String initialMessage = initialException.getMessage() == null
-                ? initialException.toString()
-                : initialException.getMessage();
+        // Fall back to Throwable#toString when the exception message is blank to keep the error debuggable.
+        String primaryMessage = StringUtils.defaultIfBlank(
+                fallbackException.getMessage(), fallbackException.toString());
+        String initialMessage = StringUtils.defaultIfBlank(
+                initialException.getMessage(), initialException.toString());
         AnalysisException mergedException = new AnalysisException(
                 "Delete failed with 2 causes. Primary cause: " + primaryMessage
                         + ". Initial predicate-check failure: " + initialMessage + ".",

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommandTest.java
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+import org.apache.doris.nereids.exceptions.AnalysisException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DeleteFromCommandTest {
+
+    @Test
+    public void testBuildDeleteFallbackException() {
+        // Verify that the merged exception exposes both failure causes and keeps the fallback cause.
+        Exception initialException = new Exception("Where clause only supports compound predicate");
+        Exception fallbackException = new Exception("disk path exceeds limit");
+
+        AnalysisException mergedException =
+                DeleteFromCommand.buildDeleteFallbackException(initialException, fallbackException);
+
+        Assertions.assertEquals(
+                "Delete failed with 2 causes. Primary cause: disk path exceeds limit."
+                        + " Initial predicate-check failure: Where clause only supports compound predicate.",
+                mergedException.getMessage());
+        Assertions.assertSame(fallbackException, mergedException.getCause());
+        Assertions.assertEquals(1, mergedException.getSuppressed().length);
+        Assertions.assertSame(initialException, mergedException.getSuppressed()[0]);
+    }
+
+    @Test
+    public void testBuildDeleteFallbackExceptionUsesThrowableToStringWhenMessageIsNull() {
+        // Verify that null messages still produce a usable merged error.
+        Exception initialException = new Exception((String) null);
+        Exception fallbackException = new Exception((String) null);
+
+        AnalysisException mergedException =
+                DeleteFromCommand.buildDeleteFallbackException(initialException, fallbackException);
+
+        Assertions.assertTrue(mergedException.getMessage().contains("Primary cause: java.lang.Exception"));
+        Assertions.assertTrue(
+                mergedException.getMessage().contains("Initial predicate-check failure: java.lang.Exception"));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommandTest.java
@@ -55,4 +55,18 @@ public class DeleteFromCommandTest {
         Assertions.assertTrue(
                 mergedException.getMessage().contains("Initial predicate-check failure: java.lang.Exception"));
     }
+
+    @Test
+    public void testBuildDeleteFallbackExceptionUsesThrowableToStringWhenMessageIsBlank() {
+        // Verify that blank messages still produce a usable merged error.
+        Exception initialException = new Exception("   ");
+        Exception fallbackException = new Exception("");
+
+        AnalysisException mergedException =
+                DeleteFromCommand.buildDeleteFallbackException(initialException, fallbackException);
+
+        Assertions.assertTrue(mergedException.getMessage().contains("Primary cause: java.lang.Exception"));
+        Assertions.assertTrue(
+                mergedException.getMessage().contains("Initial predicate-check failure: java.lang.Exception"));
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: https://github.com/apache/doris/pull/65697

Problem Summary: Preserve both the initial predicate-check failure and the real fallback execution failure when `DeleteFromUsing` fallback also fails.

### Release note

None

### Check List (For Author)

- Test: FE Unit Test
  - `./run-fe-ut.sh --run org.apache.doris.nereids.trees.plans.commands.DeleteFromCommandTest`
- Behavior changed: Yes (delete fallback errors now expose both causes)
- Does this need documentation: No