### PR TITLE
[fix](fe) Exit observer on BDBJE rollback exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
@@ -24,6 +24,7 @@ import org.apache.doris.common.LogUtils;
 import org.apache.doris.common.io.DataOutputBuffer;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.NetUtils;
+import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.journal.Journal;
 import org.apache.doris.journal.JournalBatch;
 import org.apache.doris.journal.JournalCursor;
@@ -677,7 +678,8 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
                 if (!Env.isCheckpointThread()) {
                     // Because Doris FE can not rollback its edit log, so it should restart and replay the new master's
                     // edit log.
-                    if (rollbackEx.getEarliestTransactionId() != 0) {
+                    if (Env.getCurrentEnv().getFeType() == FrontendNodeType.OBSERVER
+                            || rollbackEx.getEarliestTransactionId() != 0) {
                         LOG.error("Catch rollback log exception and it may have replayed outdated "
                                 + "logs, so exec System.exit(-1).", rollbackEx);
                         System.exit(-1);

--- a/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBJEJournalTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBJEJournalTest.java
@@ -21,6 +21,8 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.journal.JournalBatch;
 import org.apache.doris.journal.JournalCursor;
 import org.apache.doris.journal.JournalEntity;
@@ -30,6 +32,7 @@ import org.apache.doris.system.SystemInfoService.HostInfo;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.sleepycat.je.rep.ReplicatedEnvironment;
+import com.sleepycat.je.rep.RollbackException;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.io.FileUtils;
@@ -50,6 +53,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BDBJEJournalTest { // CHECKSTYLE IGNORE THIS LINE: BDBJE should use uppercase
     private static final Logger LOG = LogManager.getLogger(BDBJEJournalTest.class);
@@ -336,5 +343,51 @@ public class BDBJEJournalTest { // CHECKSTYLE IGNORE THIS LINE: BDBJE should use
         Assertions.assertEquals(11, journalId);
 
         journal.close();
+    }
+
+    @RepeatedTest(1)
+    public void testObserverExitOnRollbackWithZeroEarliestTransactionId() {
+        AtomicInteger exitStatus = new AtomicInteger();
+        new MockUp<Env>() {
+            @Mock
+            public String getBdbDir() {
+                return "";
+            }
+
+            @Mock
+            public HostInfo getSelfNode() {
+                return new HostInfo("127.0.0.1", 9010);
+            }
+
+            @Mock
+            public FrontendNodeType getFeType() {
+                return FrontendNodeType.OBSERVER;
+            }
+
+            @Mock
+            public boolean isCheckpointThread() {
+                return false;
+            }
+        };
+        new MockUp<System>() {
+            @Mock
+            public void exit(int status) {
+                exitStatus.set(status);
+                throw new ExitException();
+            }
+        };
+
+        RollbackException rollbackEx = mock(RollbackException.class);
+        when(rollbackEx.getEarliestTransactionId()).thenReturn(0L);
+        BDBEnvironment bdbEnvironment = mock(BDBEnvironment.class);
+        when(bdbEnvironment.getDatabaseNames()).thenThrow(rollbackEx);
+        BDBJEJournal journal = new BDBJEJournal("observer");
+        Deencapsulation.setField(journal, "bdbEnvironment", bdbEnvironment);
+
+        Assertions.assertThrows(ExitException.class, journal::getDatabaseNames);
+        Assertions.assertEquals(-1, exitStatus.get());
+    }
+
+    private static class ExitException extends RuntimeException {
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #31687

When an Observer reconnects after FE master failover, BDBJE may hard-roll back a divergent journal suffix and throw `RollbackException`. Doris cannot roll back its in-memory catalog or replayed journal ID.

The existing code exits only when `getEarliestTransactionId() != 0`; otherwise it reopens the BDBJE environment in-process. If the transaction ID is zero during the exception publication race, the Observer can miss the new master information journal and continue forwarding requests to the old master.

This PR makes the smallest behavior change: extend the existing condition to exit when the current FE is an Observer, while preserving the original `earliestTransactionId != 0` behavior for all other FE roles.

### Release note

FE Observers now exit for recovery whenever BDBJE reports a rollback exception.

### Check List (For Author)

- Test: Unit Test
  - `BDBJEJournalTest#testObserverExitOnRollbackWithZeroEarliestTransactionId`
  - Result: 1 test run, 0 failures, 0 errors; full Maven reactor `BUILD SUCCESS`
- Behavior changed: Yes. Observer nodes now exit on `RollbackException` even when `earliestTransactionId` is zero.
- Does this need documentation: No
