### PR TITLE
[fix](fe) Restore public assert_true registration in branch-3.1

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
@@ -556,6 +556,8 @@ public class BuiltinScalarFunctions implements FunctionHelper {
             scalar(ArrayZip.class, "array_zip"),
             scalar(ArraysOverlap.class, "arrays_overlap"),
             scalar(Ascii.class, "ascii"),
+            // Restore public SQL binding for assert_true in branch-3.1.
+            scalar(org.apache.doris.nereids.trees.expressions.functions.scalar.AssertTrue.class, "assert_true"),
             scalar(Asin.class, "asin"),
             scalar(Atan.class, "atan"),
             scalar(Atan2.class, "atan2"),

--- a/regression-test/suites/query_p0/sql_functions/conditional_functions/test_assert_true.groovy
+++ b/regression-test/suites/query_p0/sql_functions/conditional_functions/test_assert_true.groovy
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_assert_true") {
+    // Prepare a stable table for validating non-literal message binding.
+    sql """ DROP TABLE IF EXISTS test_assert_true """
+    sql """
+        CREATE TABLE test_assert_true (
+            id INT
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1"
+        )
+    """
+    sql """ INSERT INTO test_assert_true VALUES (1) """
+
+    // Validate public SQL behavior through the original planner path.
+    sql """ SET enable_nereids_planner=false """
+    sql """ SET enable_fallback_to_original_planner=true """
+
+    test {
+        sql """ SELECT assert_true(TRUE, 'assert_true should be available') """
+        result([[true]])
+    }
+
+    test {
+        sql """ SELECT assert_true(FALSE, 'assert_true false message') """
+        exception "assert_true false message"
+    }
+
+    test {
+        sql """ SELECT assert_true(NULL, 'assert_true null message') """
+        exception "assert_true null message"
+    }
+
+    test {
+        sql """ SELECT assert_true(TRUE, CAST(id AS STRING)) FROM test_assert_true """
+        exception "assert_true only accept constant for 2nd argument"
+    }
+
+    // Validate the same public SQL behavior through the Nereids path.
+    sql """ SET enable_nereids_planner=true """
+    sql """ SET enable_fallback_to_original_planner=false """
+
+    test {
+        sql """ SELECT assert_true(TRUE, 'assert_true should be available') """
+        result([[true]])
+    }
+
+    test {
+        sql """ SELECT assert_true(FALSE, 'assert_true false message') """
+        exception "assert_true false message"
+    }
+
+    test {
+        sql """ SELECT assert_true(NULL, 'assert_true null message') """
+        exception "assert_true null message"
+    }
+
+    test {
+        sql """ SELECT assert_true(TRUE, CAST(id AS STRING)) FROM test_assert_true """
+        exception "assert_true only accept constant for 2nd argument"
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #71

Related PR: None

Problem Summary: Restore the FE public builtin registration for assert_true in branch-3.1 so user SQL can resolve and execute the function again.

### Release note

Fixes a SQL compatibility regression in branch-3.1 where assert_true could not be resolved from user SQL.

### Check List (For Author)

- Test: Manual test
    - Verified on remote Doris 3.1.4-hydcp-1.2 instance at port 9034 before and after FE deployment
- Behavior changed: Yes (restores public SQL compatibility for assert_true)
- Does this need documentation: No