### PR TITLE
[fix](fe) Fix Nereids sql_digest generation in audit log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/LogicalPlanAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/LogicalPlanAdapter.java
@@ -49,10 +49,19 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
     private ArrayList<String> colLabels;
     private List<FieldInfo> fieldInfos;
     private List<String> viewDdlSqls;
+    // Cache the digest from the logical plan so audit logging can reuse it.
+    private String digest = "";
 
+    /**
+     * Initialize the digest for normal query flows and keep proxy behavior unchanged.
+     */
     public LogicalPlanAdapter(LogicalPlan logicalPlan, StatementContext statementContext) {
         this.logicalPlan = logicalPlan;
         this.statementContext = statementContext;
+        if (statementContext != null && statementContext.getConnectContext() != null
+                && !statementContext.getConnectContext().isProxy()) {
+            digest = logicalPlan == null ? "" : logicalPlan.toDigest();
+        }
     }
 
     @Override
@@ -137,8 +146,7 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
     }
 
     public String toDigest() {
-        // TODO: generate real digest
-        return "";
+        return digest;
     }
 
     public static LogicalPlanAdapter of(Plan plan) {

--- a/regression-test/suites/audit/test_sql_digest_generation.groovy 
+++ b/regression-test/suites/audit/test_sql_digest_generation.groovy 
@@ -53,6 +53,48 @@ suite("test_sql_digest_generation", "nonConcurrent") {
         logger.info("now sql_digest count: " + nowSqlDigestCount)
 
         assertTrue(nowSqlDigestCount > prevSqlDigestCount, "Count of sql_digest did not increase")
+
+        // Verify that Nereids digest generation distinguishes query shapes.
+        sql """ set enable_nereids_planner = true """
+        sql """ set enable_fallback_to_original_planner = false """
+        def sameShapeSql1 = "select 1 as sql_digest_same_shape_case"
+        def sameShapeSql2 = "select 2 as sql_digest_same_shape_case"
+        def diffShapeSql = "select 1 + 1 as sql_digest_diff_shape_case"
+        sql sameShapeSql1
+        sql sameShapeSql2
+        sql diffShapeSql
+
+        Thread.sleep(10000)
+        sql """call flush_audit_log()"""
+
+        def sameShapeDigest1 = sql """
+            SELECT sql_digest
+            FROM __internal_schema.audit_log
+            WHERE stmt = '${sameShapeSql1}'
+            ORDER BY time DESC
+            LIMIT 1
+        """
+        def sameShapeDigest2 = sql """
+            SELECT sql_digest
+            FROM __internal_schema.audit_log
+            WHERE stmt = '${sameShapeSql2}'
+            ORDER BY time DESC
+            LIMIT 1
+        """
+        def diffShapeDigest = sql """
+            SELECT sql_digest
+            FROM __internal_schema.audit_log
+            WHERE stmt = '${diffShapeSql}'
+            ORDER BY time DESC
+            LIMIT 1
+        """
+
+        assertTrue(sameShapeDigest1.size() == 1 && sameShapeDigest2.size() == 1 && diffShapeDigest.size() == 1,
+                "Failed to fetch sql_digest rows for Nereids queries")
+        assertTrue(sameShapeDigest1[0][0] == sameShapeDigest2[0][0],
+                "Same-shape queries should share the same sql_digest")
+        assertTrue(sameShapeDigest1[0][0] != diffShapeDigest[0][0],
+                "Different query shapes should not share the same sql_digest")
     }
 
     Thread.sleep(10000)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Fix the Nereids audit sql_digest regression in branch-3.1 by caching the logical plan digest in `LogicalPlanAdapter`, and add regression coverage to verify same-shape queries share a digest while different query shapes do not.

### Release note

Fixes a branch-3.1 regression where Nereids audit `sql_digest` could degrade to the same empty-string digest for different SQL statements.

### Check List (For Author)

- Test: Manual test
    - Verified on remote Doris 3.1.4 instance at port 9034 after FE rebuild and restart
    - Confirmed same-shape queries share the same digest and different-shape queries produce different digests
- Behavior changed: Yes (restores correct Nereids audit sql_digest behavior)
- Does this need documentation: No