### PR TITLE
[fix](binlog) Return BINLOG_NOT_FOUND_TABLE for dropped tables in binlog APIs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/DBBinlog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/DBBinlog.java
@@ -45,6 +45,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -69,6 +70,8 @@ public class DBBinlog {
     private List<Pair<Long, Long>> droppedPartitions;
     // The commit seq of the dropped tables
     private List<Pair<Long, Long>> droppedTables;
+    // Ids of the dropped tables, mirrors droppedTables for O(1) lookup
+    private Set<Long> droppedTableIds;
     // The commit seq of the dropped indexes
     private List<Pair<Long, Long>> droppedIndexes;
 
@@ -93,6 +96,7 @@ public class DBBinlog {
         timestamps = Lists.newArrayList();
         droppedPartitions = Lists.newArrayList();
         droppedTables = Lists.newArrayList();
+        droppedTableIds = Sets.newHashSet();
         droppedIndexes = Lists.newArrayList();
         lockedBinlogs = Maps.newHashMap();
 
@@ -216,6 +220,13 @@ public class DBBinlog {
         lock.readLock().lock();
         try {
             if (tableId >= 0) {
+                // Check if table is dropped first, before checking tableBinlogMap
+                if (isTableDropped(tableId)) {
+                    LOG.warn("table is dropped. tableId: {}", tableId);
+                    status.setStatusCode(TStatusCode.BINLOG_NOT_FOUND_TABLE);
+                    return Pair.of(status, null);
+                }
+
                 TableBinlog tableBinlog = tableBinlogMap.get(tableId);
                 if (tableBinlog == null) {
                     LOG.warn("table binlog not found. tableId: {}", tableId);
@@ -266,6 +277,13 @@ public class DBBinlog {
         lock.readLock().lock();
         try {
             if (tableId >= 0) {
+                // Check if table is dropped first, before checking tableBinlogMap
+                if (isTableDropped(tableId)) {
+                    LOG.warn("table is dropped. tableId: {}", tableId);
+                    status.setStatusCode(TStatusCode.BINLOG_NOT_FOUND_TABLE);
+                    return Pair.of(status, null);
+                }
+
                 TableBinlog tableBinlog = tableBinlogMap.get(tableId);
                 if (tableBinlog == null) {
                     LOG.warn("table binlog not found. tableId: {}", tableId);
@@ -287,6 +305,12 @@ public class DBBinlog {
         try {
             if (tableId < 0) {
                 return lockDbBinlog(jobUniqueId, lockCommitSeq);
+            }
+
+            // Check if table is dropped first, before checking tableBinlogMap
+            if (isTableDropped(tableId)) {
+                LOG.warn("table is dropped. dbId: {}, tableId: {}", dbId, tableId);
+                return Pair.of(new TStatus(TStatusCode.BINLOG_NOT_FOUND_TABLE), -1L);
             }
 
             tableBinlog = tableBinlogMap.get(tableId);
@@ -609,8 +633,17 @@ public class DBBinlog {
             iter.remove();
         }
         iter = droppedTables.iterator();
+        boolean droppedTablesChanged = false;
         while (iter.hasNext() && iter.next().second < commitSeq) {
             iter.remove();
+            droppedTablesChanged = true;
+        }
+        if (droppedTablesChanged) {
+            // keep droppedTableIds consistent with droppedTables
+            droppedTableIds.clear();
+            for (Pair<Long, Long> entry : droppedTables) {
+                droppedTableIds.add(entry.first);
+            }
         }
         iter = droppedIndexes.iterator();
         while (iter.hasNext() && iter.next().second < commitSeq) {
@@ -631,6 +664,11 @@ public class DBBinlog {
         } finally {
             lock.writeLock().unlock();
         }
+    }
+
+    // Require: the lock is held by the caller.
+    private boolean isTableDropped(long tableId) {
+        return droppedTableIds.contains(tableId);
     }
 
     public void getBinlogInfo(BaseProcResult result) {
@@ -761,6 +799,7 @@ public class DBBinlog {
             long tableId = ((DropTableRecord) raw).getTableId();
             if (tableId > 0) {
                 droppedTables.add(Pair.of(tableId, commitSeq));
+                droppedTableIds.add(tableId);
             }
         } else if (binlogType == TBinlogType.ALTER_JOB && raw instanceof AlterJobRecord) {
             AlterJobRecord alterJobRecord = (AlterJobRecord) raw;
@@ -780,6 +819,7 @@ public class DBBinlog {
             ReplaceTableOperationLog record = (ReplaceTableOperationLog) raw;
             if (!record.isSwapTable()) {
                 droppedTables.add(Pair.of(record.getOrigTblId(), commitSeq));
+                droppedTableIds.add(record.getOrigTblId());
             }
         } else if (binlogType == TBinlogType.DROP_ROLLUP && raw instanceof DropInfo) {
             long indexId = ((DropInfo) raw).getIndexId();
@@ -800,6 +840,7 @@ public class DBBinlog {
                 droppedPartitions.removeIf(entry -> (entry.first == partitionId));
             } else if (tableId > 0) {
                 droppedTables.removeIf(entry -> (entry.first == tableId));
+                droppedTableIds.remove(tableId);
             }
         } else if ((binlogType == TBinlogType.REPLACE_PARTITIONS) && (raw instanceof ReplacePartitionOperationLog)) {
             ReplacePartitionOperationLog replacePartitionOperationLog = (ReplacePartitionOperationLog) raw;

--- a/fe/fe-core/src/test/java/org/apache/doris/binlog/DbBinlogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/binlog/DbBinlogTest.java
@@ -17,8 +17,13 @@
 
 package org.apache.doris.binlog;
 
+import org.apache.doris.common.Pair;
+import org.apache.doris.persist.RecoverInfo;
+import org.apache.doris.persist.ReplaceTableOperationLog;
 import org.apache.doris.thrift.TBinlog;
 import org.apache.doris.thrift.TBinlogType;
+import org.apache.doris.thrift.TStatus;
+import org.apache.doris.thrift.TStatusCode;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -421,5 +426,150 @@ public class DbBinlogTest {
         // check tombstone
         Assert.assertTrue(tombstone.isDbBinlogTomstone());
         Assert.assertEquals(expiredTime, tombstone.getCommitSeq());
+    }
+
+    private DBBinlog newEnabledDbBinlog(long tableId) {
+        new MockUp<BinlogConfigCache>() {
+            @Mock
+            boolean isEnableDB(long dbId) {
+                return true;
+            }
+
+            @Mock
+            boolean isEnableTable(long dbId, long tableId) {
+                return true;
+            }
+        };
+
+        DBBinlog dbBinlog = new DBBinlog(new BinlogConfigCache(),
+                BinlogTestUtils.newBinlog(dbId, tableId, 1, 1));
+        // add a normal binlog so that tableBinlogMap contains the table entry
+        dbBinlog.addBinlog(BinlogTestUtils.newBinlog(dbId, tableId, 2, 2), null);
+        return dbBinlog;
+    }
+
+    private void addDropTableBinlog(DBBinlog dbBinlog, long tableId, long commitSeq) {
+        TBinlog binlog = BinlogTestUtils.newBinlog(dbId, tableId, commitSeq, commitSeq);
+        binlog.setType(TBinlogType.DROP_TABLE);
+        DropTableRecord record = DropTableRecord.fromJson("{\"tableId\":" + tableId + "}");
+        dbBinlog.addBinlog(binlog, record);
+    }
+
+    @Test
+    public void testGetBinlogAfterDropTable() {
+        DBBinlog dbBinlog = newEnabledDbBinlog(baseTableId);
+
+        // before drop: all table level APIs work
+        Assert.assertEquals(TStatusCode.OK,
+                dbBinlog.getBinlog(baseTableId, -1, 10).first.getStatusCode());
+        Assert.assertEquals(TStatusCode.OK,
+                dbBinlog.getBinlogLag(baseTableId, -1).first.getStatusCode());
+        Assert.assertEquals(TStatusCode.OK,
+                dbBinlog.lockBinlog(baseTableId, "job1", -1).first.getStatusCode());
+
+        addDropTableBinlog(dbBinlog, baseTableId, 3);
+
+        // after drop: all table level APIs return BINLOG_NOT_FOUND_TABLE immediately
+        Pair<TStatus, List<TBinlog>> binlogResult = dbBinlog.getBinlog(baseTableId, -1, 10);
+        Assert.assertEquals(TStatusCode.BINLOG_NOT_FOUND_TABLE, binlogResult.first.getStatusCode());
+        Pair<TStatus, BinlogLagInfo> lagResult = dbBinlog.getBinlogLag(baseTableId, -1);
+        Assert.assertEquals(TStatusCode.BINLOG_NOT_FOUND_TABLE, lagResult.first.getStatusCode());
+        Pair<TStatus, Long> lockResult = dbBinlog.lockBinlog(baseTableId, "job1", -1);
+        Assert.assertEquals(TStatusCode.BINLOG_NOT_FOUND_TABLE, lockResult.first.getStatusCode());
+        Assert.assertEquals(-1L, (long) lockResult.second);
+
+        // db level binlog (tableId = -1) is not affected by dropped tables
+        Assert.assertNotEquals(TStatusCode.BINLOG_NOT_FOUND_TABLE,
+                dbBinlog.getBinlog(-1, -1, 10).first.getStatusCode());
+        Assert.assertNotEquals(TStatusCode.BINLOG_NOT_FOUND_TABLE,
+                dbBinlog.getBinlogLag(-1, -1).first.getStatusCode());
+        Assert.assertNotEquals(TStatusCode.BINLOG_NOT_FOUND_TABLE,
+                dbBinlog.lockBinlog(-1, "job2", -1).first.getStatusCode());
+    }
+
+    @Test
+    public void testGetBinlogAfterRecoverTable() {
+        DBBinlog dbBinlog = newEnabledDbBinlog(baseTableId);
+        addDropTableBinlog(dbBinlog, baseTableId, 3);
+        Assert.assertEquals(TStatusCode.BINLOG_NOT_FOUND_TABLE,
+                dbBinlog.getBinlog(baseTableId, -1, 10).first.getStatusCode());
+
+        // recover the table, the dropped signal should be cleared automatically
+        TBinlog binlog = BinlogTestUtils.newBinlog(dbId, baseTableId, 4, 4);
+        binlog.setType(TBinlogType.RECOVER_INFO);
+        RecoverInfo recoverInfo = RecoverInfo.fromJson("{\"tableId\":" + baseTableId + "}");
+        dbBinlog.addBinlog(binlog, recoverInfo);
+
+        Assert.assertEquals(TStatusCode.OK,
+                dbBinlog.getBinlog(baseTableId, -1, 10).first.getStatusCode());
+        Assert.assertEquals(TStatusCode.OK,
+                dbBinlog.getBinlogLag(baseTableId, -1).first.getStatusCode());
+        Assert.assertEquals(TStatusCode.OK,
+                dbBinlog.lockBinlog(baseTableId, "job1", -1).first.getStatusCode());
+    }
+
+    @Test
+    public void testDropAndRecreateTableWithSameName() {
+        DBBinlog dbBinlog = newEnabledDbBinlog(baseTableId);
+        addDropTableBinlog(dbBinlog, baseTableId, 3);
+
+        // recreate a table with the same name, the new table gets a new table id
+        long newTableId = baseTableId + 100;
+        dbBinlog.addBinlog(BinlogTestUtils.newBinlog(dbId, newTableId, 4, 4), null);
+
+        // the old id keeps reporting BINLOG_NOT_FOUND_TABLE, the new id works
+        Assert.assertEquals(TStatusCode.BINLOG_NOT_FOUND_TABLE,
+                dbBinlog.getBinlog(baseTableId, -1, 10).first.getStatusCode());
+        Assert.assertEquals(TStatusCode.OK,
+                dbBinlog.getBinlog(newTableId, -1, 10).first.getStatusCode());
+    }
+
+    @Test
+    public void testReplaceTableDroppedSignal() {
+        DBBinlog dbBinlog = newEnabledDbBinlog(baseTableId);
+
+        // replace table with swap: neither table is treated as dropped
+        TBinlog swapBinlog = BinlogTestUtils.newBinlog(dbId, baseTableId, 3, 3);
+        swapBinlog.setType(TBinlogType.REPLACE_TABLE);
+        ReplaceTableOperationLog swapLog = ReplaceTableOperationLog.fromJson(
+                "{\"origTblId\":" + baseTableId + ",\"swapTable\":true}");
+        dbBinlog.addBinlog(swapBinlog, swapLog);
+        Assert.assertEquals(TStatusCode.OK,
+                dbBinlog.getBinlog(baseTableId, -1, 10).first.getStatusCode());
+
+        // replace table without swap: the orig table is treated as dropped
+        TBinlog replaceBinlog = BinlogTestUtils.newBinlog(dbId, baseTableId, 4, 4);
+        replaceBinlog.setType(TBinlogType.REPLACE_TABLE);
+        ReplaceTableOperationLog replaceLog = ReplaceTableOperationLog.fromJson(
+                "{\"origTblId\":" + baseTableId + ",\"swapTable\":false}");
+        dbBinlog.addBinlog(replaceBinlog, replaceLog);
+        Assert.assertEquals(TStatusCode.BINLOG_NOT_FOUND_TABLE,
+                dbBinlog.getBinlog(baseTableId, -1, 10).first.getStatusCode());
+    }
+
+    @Test
+    public void testDroppedTableSignalClearedByGc() {
+        // db binlog enabled, all binlogs with timestamp <= expiredTime will be gc'd
+        long expiredTime = 10;
+        Map<String, Long> ttlMap = Maps.newHashMap();
+        MockBinlogConfigCache binlogConfigCache = BinlogTestUtils.newMockBinlogConfigCache(ttlMap);
+        binlogConfigCache.addDbBinlogConfig(dbId, true, expiredTime);
+        binlogConfigCache.addTableBinlogConfig(dbId, baseTableId, true, expiredTime);
+
+        DBBinlog dbBinlog = new DBBinlog(binlogConfigCache,
+                BinlogTestUtils.newBinlog(dbId, baseTableId, 1, 1));
+        dbBinlog.addBinlog(BinlogTestUtils.newBinlog(dbId, baseTableId, 1, 1), null);
+        addDropTableBinlog(dbBinlog, baseTableId, 2);
+        // one more binlog after the drop, so that gcDroppedResources can expire the drop record
+        dbBinlog.addBinlog(BinlogTestUtils.newBinlog(dbId, baseTableId, 3, 3), null);
+
+        Assert.assertEquals(TStatusCode.BINLOG_NOT_FOUND_TABLE,
+                dbBinlog.getBinlog(baseTableId, -1, 10).first.getStatusCode());
+
+        // the drop record (commitSeq 2) is expired by gc, the signal is cleared
+        dbBinlog.gc();
+        Assert.assertTrue(dbBinlog.getDroppedTables().isEmpty());
+        Assert.assertNotEquals(TStatusCode.BINLOG_NOT_FOUND_TABLE,
+                dbBinlog.getBinlog(baseTableId, -1, 10).first.getStatusCode());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
After a table is dropped, its entry in DBBinlog.tableBinlogMap is never removed (neither by drop nor by GC), so the binlog APIs (getBinlog, getBinlogLag, lockBinlog) keep responding as if the table still exists. TableSync consumers such as ccr-syncer then poll forever with no progress and no explicit error, and a dropped table sync job can only be noticed by manual inspection.

DBBinlog already tracks dropped tables in its droppedTables list (recorded from DROP_TABLE / non-swap REPLACE_TABLE binlogs, removed on RECOVER_INFO), but this fact was not wired to the API surface. This change checks the dropped table ids in getBinlog, getBinlogLag and lockBinlog before consulting tableBinlogMap, and returns BINLOG_NOT_FOUND_TABLE immediately when the table has been dropped. The status code already exists in the protocol and is handled by all ccr-syncer versions, so no consumer change is required.

The dropped ids are maintained in a HashSet alongside droppedTables for O(1) lookup on the hot path: updated in recordDroppedOrRecoveredResources (DROP_TABLE / REPLACE_TABLE add, RECOVER_INFO removes so a recovered table resumes incremental sync automatically) and rebuilt in gcDroppedResources after trimming, which bounds the signal window to the binlog ttl as before.

### Known limitations (accepted trade-offs)

- **The signal is anchored to the binlog retention window, not to actual table existence.** droppedTables entries (and their HashSet index) are trimmed by binlog GC once the drop's commitSeq falls behind the GC watermark (ttl / max_bytes / max_history_nums, and possibly earlier due to lock-based GC acceleration). After that, the APIs fall back to the pre-change behavior (TOO_OLD / TOO_NEW on the lingering TableBinlog shell) and the sync job goes silent again. Alerts must be consumed within the window; out-of-window detection is expected to be covered by external inspection (planned separately). Setting binlog_ttl_seconds larger than the alert-response SLA widens the window.
- **The signal rides on droppedTables, which also serves the get_meta snapshot protocol.** The two consumers have different lifetime requirements (window-bound event index vs existence tombstone); this PR keeps them unified to stay minimal, at the cost of the signal's persistence.
- **No independent persistence.** The dropped-table state is rebuilt from the persisted binlog stream on FE restart, so the same ttl window applies after restart.
- **ccr-syncer caveats that dilute the signal** (to be fixed separately in ccr-syncer): BINLOG_TOO_OLD_COMMIT_SEQ is silently skipped, and /get_lag does not check the returned status code.
- Each stuck TableSync job produces one FE-side warn log per poll tick until the job is handled.

A follow-up may decouple the tombstone into an independently persisted set (stored in the FE image, removed only by RECOVER_INFO or db drop) if the ttl window proves insufficient in practice. The API contract (BINLOG_NOT_FOUND_TABLE, cleared on recover) stays the same.

### Release note

For a dropped table, the FE binlog APIs (getBinlog, getBinlogLag, lockBinlog) now return BINLOG_NOT_FOUND_TABLE instead of behaving as if the table still exists. Binlog consumers (e.g. ccr-syncer TableSync jobs) will surface explicit errors (warn logs and error metrics) instead of silently polling without progress. The signal lasts as long as the binlog retention window (binlog_ttl_seconds); after the drop record is reclaimed by binlog GC, the APIs return to the previous behavior.

### Check List (For Author)

- Test: Unit Test (DbBinlogTest: drop / recover / recreate-with-same-name / replace-table (swap and non-swap) / signal-cleared-by-gc cases; BinlogManagerTest and TableBinlogTest as regression)
- Behavior changed: Yes (binlog APIs return BINLOG_NOT_FOUND_TABLE for dropped tables within the binlog retention window)
- Does this need documentation: No
