### PR TITLE
[fix](fe) Preserve table binlog config for replace

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -50,6 +50,7 @@ import org.apache.doris.analysis.ReplaceTableClause;
 import org.apache.doris.analysis.RollupRenameClause;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.analysis.TableRenameClause;
+import org.apache.doris.catalog.BinlogConfig;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DataProperty;
 import org.apache.doris.catalog.Database;
@@ -677,10 +678,11 @@ public class Alter {
                 if (swapTable) {
                     origTable.checkAndSetName(newTblName, true);
                 }
+                BinlogConfig origTblBinlogConfig = new BinlogConfig(origTable.getBinlogConfig());
                 replaceTableInternal(db, origTable, olapNewTbl, swapTable, false);
                 // write edit log
                 ReplaceTableOperationLog log = new ReplaceTableOperationLog(db.getId(),
-                        origTable.getId(), oldTblName, olapNewTbl.getId(), newTblName, swapTable);
+                        origTable.getId(), oldTblName, olapNewTbl.getId(), newTblName, swapTable, origTblBinlogConfig);
                 Env.getCurrentEnv().getEditLog().logReplaceTable(log);
                 LOG.info("finish replacing table {} with table {}, is swap: {}", oldTblName, newTblName, swapTable);
             } finally {
@@ -704,6 +706,7 @@ public class Alter {
         tableList.sort((Comparator.comparing(Table::getId)));
         MetaLockUtils.writeLockTablesOrMetaException(tableList);
         try {
+            Env.getCurrentEnv().getBinlogManager().cacheTableBinlogConfig(origTblId, log.getOrigTblBinlogConfig());
             replaceTableInternal(db, origTable, newTbl, log.isSwapTable(), true);
         } catch (DdlException e) {
             LOG.warn("should not happen", e);

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogConfigCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogConfigCache.java
@@ -164,6 +164,15 @@ public class BinlogConfigCache {
         return tableBinlogConfig.getTtlSeconds();
     }
 
+    public void putTableBinlogConfig(long tableId, BinlogConfig binlogConfig) {
+        lock.writeLock().lock();
+        try {
+            dbTableBinlogEnableMap.put(tableId, new BinlogConfig(binlogConfig));
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
     public void remove(long id) {
         lock.writeLock().lock();
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
@@ -19,6 +19,7 @@ package org.apache.doris.binlog;
 
 import org.apache.doris.alter.AlterJobV2;
 import org.apache.doris.alter.IndexChangeJob;
+import org.apache.doris.catalog.BinlogConfig;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
@@ -181,11 +182,7 @@ public class BinlogManager {
         if (tableIds != null) {
             for (long tableId : tableIds) {
                 boolean tableBinlogEnable = binlogConfigCache.isEnableTable(dbId, tableId);
-                if (tableIds.size() > 1) {
-                    anyEnable = anyEnable || tableBinlogEnable;
-                } else {
-                    anyEnable = tableBinlogEnable;
-                }
+                anyEnable = anyEnable || tableBinlogEnable;
                 if (anyEnable) {
                     break;
                 }
@@ -295,6 +292,7 @@ public class BinlogManager {
         long dbId = info.getDbId();
         List<Long> tableIds = Lists.newArrayList();
         tableIds.add(info.getTableId());
+        refreshTableBinlogConfig(dbId, info.getTableId());
         long timestamp = System.currentTimeMillis();
         TBinlogType type = TBinlogType.MODIFY_TABLE_PROPERTY;
         String data = info.toJson();
@@ -431,6 +429,7 @@ public class BinlogManager {
         }
 
         long dbId = info.getDbId();
+        cacheTableBinlogConfig(info.getOrigTblId(), info.getOrigTblBinlogConfig());
         List<Long> tableIds = Lists.newArrayList();
         tableIds.add(info.getOrigTblId());
         long timestamp = System.currentTimeMillis();
@@ -438,6 +437,29 @@ public class BinlogManager {
         String data = info.toJson();
 
         addBinlog(dbId, tableIds, commitSeq, timestamp, type, data, false, info);
+    }
+
+    public void cacheTableBinlogConfig(long tableId, BinlogConfig binlogConfig) {
+        if (binlogConfig != null) {
+            binlogConfigCache.putTableBinlogConfig(tableId, binlogConfig);
+            updateTableBinlogConfig(tableId, binlogConfig);
+        }
+    }
+
+    private void refreshTableBinlogConfig(long dbId, long tableId) {
+        binlogConfigCache.remove(tableId);
+        cacheTableBinlogConfig(tableId, binlogConfigCache.getTableBinlogConfig(dbId, tableId));
+    }
+
+    private void updateTableBinlogConfig(long tableId, BinlogConfig binlogConfig) {
+        lock.readLock().lock();
+        try {
+            for (DBBinlog dbBinlog : dbBinlogMap.values()) {
+                dbBinlog.updateTableBinlogConfig(tableId, binlogConfig);
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     public void addModifyDistributionNum(ModifyTableDefaultDistributionBucketNumOperationLog info, long commitSeq) {
@@ -812,6 +834,10 @@ public class BinlogManager {
                                 currentDbBinlogEnable);
                         dbBinlogMap.put(dbId, dbBinlog);
                     } else {
+                        if (binlog.isSetData()) {
+                            binlogConfigCache.putTableBinlogConfig(binlog.getBelong(),
+                                    BinlogConfig.fromJson(binlog.getData()));
+                        }
                         tableDummies.add(binlog);
                     }
                 } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/DBBinlog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/DBBinlog.java
@@ -215,6 +215,18 @@ public class DBBinlog {
         return dbId;
     }
 
+    public void updateTableBinlogConfig(long tableId, BinlogConfig binlogConfig) {
+        lock.writeLock().lock();
+        try {
+            TableBinlog tableBinlog = tableBinlogMap.get(tableId);
+            if (tableBinlog != null) {
+                tableBinlog.updateBinlogConfig(binlogConfig);
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
     public Pair<TStatus, List<TBinlog>> getBinlog(long tableId, long prevCommitSeq, long numAcquired) {
         TStatus status = new TStatus(TStatusCode.OK);
         lock.readLock().lock();

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/TableBinlog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/TableBinlog.java
@@ -76,6 +76,10 @@ public class TableBinlog {
             dummy = binlog;
         } else {
             dummy = BinlogUtils.newDummyBinlog(binlog.getDbId(), tableId);
+            BinlogConfig binlogConfig = binlogConfigCache.getTableBinlogConfig(dbId, tableId);
+            if (binlogConfig != null) {
+                dummy.setData(binlogConfig.toString());
+            }
         }
         binlogs.add(dummy);
         this.binlogConfigCache = binlogConfigCache;
@@ -87,6 +91,15 @@ public class TableBinlog {
 
     public long getTableId() {
         return tableId;
+    }
+
+    public void updateBinlogConfig(BinlogConfig binlogConfig) {
+        lock.writeLock().lock();
+        try {
+            getDummyBinlog().setData(binlogConfig.toString());
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     // not thread safety, do this without lock
@@ -256,6 +269,9 @@ public class TableBinlog {
     public BinlogTombstone gc() {
         // step 1: get expire time
         BinlogConfig tableBinlogConfig = binlogConfigCache.getTableBinlogConfig(dbId, tableId);
+        if (tableBinlogConfig == null && getDummyBinlog().isSetData()) {
+            tableBinlogConfig = BinlogConfig.fromJson(getDummyBinlog().getData());
+        }
         Boolean isCleanFullBinlog = false;
         if (tableBinlogConfig == null) {
             return null;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BinlogConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BinlogConfig.java
@@ -189,4 +189,8 @@ public class BinlogConfig implements Writable {
         binlogConfig.mergeFromProperties(properties);
         return binlogConfig;
     }
+
+    public static BinlogConfig fromJson(String json) {
+        return GsonUtils.GSON.fromJson(json, BinlogConfig.class);
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/ReplaceTableOperationLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/ReplaceTableOperationLog.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.persist;
 
+import org.apache.doris.catalog.BinlogConfig;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;
@@ -40,16 +41,25 @@ public class ReplaceTableOperationLog implements Writable {
     private String newTblName;
     @SerializedName(value = "swapTable")
     private boolean swapTable;
+    @SerializedName(value = "origTblBinlogConfig")
+    private BinlogConfig origTblBinlogConfig;
 
     public ReplaceTableOperationLog(long dbId, long origTblId,
             String origTblName, long newTblId, String newTblName,
             boolean swapTable) {
+        this(dbId, origTblId, origTblName, newTblId, newTblName, swapTable, null);
+    }
+
+    public ReplaceTableOperationLog(long dbId, long origTblId,
+            String origTblName, long newTblId, String newTblName,
+            boolean swapTable, BinlogConfig origTblBinlogConfig) {
         this.dbId = dbId;
         this.origTblId = origTblId;
         this.origTblName = origTblName;
         this.newTblId = newTblId;
         this.newTblName = newTblName;
         this.swapTable = swapTable;
+        this.origTblBinlogConfig = origTblBinlogConfig == null ? null : new BinlogConfig(origTblBinlogConfig);
     }
 
     public long getDbId() {
@@ -74,6 +84,10 @@ public class ReplaceTableOperationLog implements Writable {
 
     public boolean isSwapTable() {
         return swapTable;
+    }
+
+    public BinlogConfig getOrigTblBinlogConfig() {
+        return origTblBinlogConfig;
     }
 
     public String toJson() {

--- a/fe/fe-core/src/test/java/org/apache/doris/binlog/ReplaceTableBinlogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/binlog/ReplaceTableBinlogTest.java
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.binlog;
+
+import org.apache.doris.catalog.BinlogConfig;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
+import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.persist.ReplaceTableOperationLog;
+import org.apache.doris.thrift.TBinlog;
+import org.apache.doris.thrift.TBinlogType;
+
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ReplaceTableBinlogTest {
+    private static final long DB_ID = 1L;
+    private static final long TABLE_ID = 2L;
+
+    @Before
+    public void setUp() {
+        Config.enable_feature_binlog = true;
+
+        Database database = new Database();
+        new MockUp<Env>() {
+            @Mock
+            public InternalCatalog getCurrentInternalCatalog() {
+                return new InternalCatalog();
+            }
+        };
+        new MockUp<InternalCatalog>() {
+            @Mock
+            public Database getDbNullable(long dbId) {
+                return database;
+            }
+        };
+        new MockUp<Database>() {
+            @Mock
+            public BinlogConfig getBinlogConfig() {
+                return new BinlogConfig();
+            }
+        };
+    }
+
+    @Test
+    public void testTableBinlogReplaceUsesPersistedOriginConfig() throws Exception {
+        BinlogManager manager = new BinlogManager();
+        ReplaceTableOperationLog replaceLog = new ReplaceTableOperationLog(DB_ID, TABLE_ID, "origin", 3L,
+                "replacement", false, new BinlogConfig(true, 3600L, Long.MAX_VALUE, Long.MAX_VALUE));
+
+        manager.addReplaceTable(replaceLog, 10L);
+
+        Field dbBinlogMapField = BinlogManager.class.getDeclaredField("dbBinlogMap");
+        dbBinlogMapField.setAccessible(true);
+        Map<Long, DBBinlog> dbBinlogMap = (Map<Long, DBBinlog>) dbBinlogMapField.get(manager);
+        List<TBinlog> binlogs = new ArrayList<>();
+        dbBinlogMap.get(DB_ID).getAllBinlogs(binlogs);
+
+        Assert.assertTrue(binlogs.stream().anyMatch(binlog -> binlog.getType() == TBinlogType.REPLACE_TABLE
+                && binlog.getCommitSeq() == 10L));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/binlog/TableBinlogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/binlog/TableBinlogTest.java
@@ -98,6 +98,36 @@ public class TableBinlogTest {
     }
 
     @Test
+    public void testGcWithConfigRecoveredFromDummy() {
+        new MockUp<BinlogUtils>() {
+            @Mock
+            public long getExpiredMs(long direct) {
+                return direct;
+            }
+        };
+
+        long expiredTime = baseNum + expiredBinlogNum;
+        Map<String, Long> ttlMap = Maps.newHashMap();
+        ttlMap.put(String.format("%d_%d", dbId, tableId), expiredTime);
+        MockBinlogConfigCache configuredCache = BinlogTestUtils.newMockBinlogConfigCache(ttlMap);
+
+        TBinlog originalBinlog = BinlogTestUtils.newBinlog(dbId, tableId, baseNum, baseNum);
+        TableBinlog original = new TableBinlog(configuredCache, originalBinlog, dbId, tableId);
+        Assert.assertTrue(original.getDummyBinlog().isSetData());
+
+        TableBinlog restored = new TableBinlog(new MockBinlogConfigCache(Maps.newHashMap()),
+                original.getDummyBinlog(), dbId, tableId);
+        TBinlog expiredBinlog = BinlogTestUtils.newBinlog(dbId, tableId, baseNum + 1, expiredTime);
+        restored.addBinlog(expiredBinlog);
+
+        BinlogTombstone tombstone = restored.gc();
+
+        Assert.assertNotNull(tombstone);
+        Assert.assertEquals(0, expiredBinlog.getTableRef());
+        Assert.assertEquals(expiredBinlog.getCommitSeq(), restored.getDummyBinlog().getCommitSeq());
+    }
+
+    @Test
     public void testCommitSeqGc() {
         // init base data
         BinlogConfigCache binlogConfigCache = BinlogTestUtils.newMockBinlogConfigCache(dbId, tableId, 0);

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/ReplaceTableOperationLogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/ReplaceTableOperationLogTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.persist;
 
+import org.apache.doris.catalog.BinlogConfig;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,30 +31,41 @@ import java.io.FileOutputStream;
 public class ReplaceTableOperationLogTest {
     @Test
     public void testSerialization() throws Exception {
-        // 1. Write objects to file
         File file = new File("./ReplaceTableOperationLogTest");
         file.createNewFile();
         DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
 
-        ReplaceTableOperationLog log = new ReplaceTableOperationLog(1, 2, "old", 3, "new", true);
+        BinlogConfig binlogConfig = new BinlogConfig(true, 3600L, 1024L, 10L);
+        ReplaceTableOperationLog log = new ReplaceTableOperationLog(1L, 2L, "origin", 3L, "replacement",
+                false, binlogConfig);
         log.write(dos);
 
         dos.flush();
         dos.close();
 
-        // 2. Read objects from file
         DataInputStream dis = new DataInputStream(new FileInputStream(file));
+        ReplaceTableOperationLog restored = ReplaceTableOperationLog.read(dis);
 
-        ReplaceTableOperationLog readLog = ReplaceTableOperationLog.read(dis);
-        Assert.assertTrue(readLog.getDbId() == log.getDbId());
-        Assert.assertTrue(readLog.getNewTblId() == log.getNewTblId());
-        Assert.assertTrue(readLog.getOrigTblId() == log.getOrigTblId());
-        Assert.assertTrue(readLog.isSwapTable() == log.isSwapTable());
-        Assert.assertTrue(readLog.getOrigTblName().equals(log.getOrigTblName()));
-        Assert.assertTrue(readLog.getNewTblName().equals(log.getNewTblName()));
+        Assert.assertEquals(log.getDbId(), restored.getDbId());
+        Assert.assertEquals(log.getNewTblId(), restored.getNewTblId());
+        Assert.assertEquals(log.getOrigTblId(), restored.getOrigTblId());
+        Assert.assertEquals(log.isSwapTable(), restored.isSwapTable());
+        Assert.assertEquals(log.getOrigTblName(), restored.getOrigTblName());
+        Assert.assertEquals(log.getNewTblName(), restored.getNewTblName());
+        Assert.assertEquals(binlogConfig, restored.getOrigTblBinlogConfig());
 
-        // 3. delete files
         dis.close();
         file.delete();
+    }
+
+    @Test
+    public void testOriginTableBinlogConfigIsPersistedInJson() {
+        BinlogConfig binlogConfig = new BinlogConfig(true, 3600L, 1024L, 10L);
+        ReplaceTableOperationLog log = new ReplaceTableOperationLog(1L, 2L, "origin", 3L, "replacement",
+                false, binlogConfig);
+
+        ReplaceTableOperationLog restored = ReplaceTableOperationLog.fromJson(log.toJson());
+
+        Assert.assertEquals(binlogConfig, restored.getOrigTblBinlogConfig());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #48919

Problem Summary:

`swap=false REPLACE TABLE` unregisters the origin table before emitting its binlog. On a cold FE cache, 3.1 cannot resolve the origin table table-level binlog configuration, so the REPLACE event may be skipped. A single-table event also overwrites a true database-level binlog setting.

This change persists the origin table `BinlogConfig` in `ReplaceTableOperationLog`, restores it before binlog replay, stores table policy in dummy binlogs for image recovery and GC, and restores DB-or-table enablement semantics.

### Release note

Fixes eligible REPLACE TABLE binlogs being skipped after cache loss, master failover, or table-level image recovery.

### Check List (For Author)

- Test: No need to test. `thirdparty/installed/bin/protoc` is absent in this worktree; FE unit tests were added and `git diff --check` passed.
- Behavior changed: Yes. Eligible REPLACE TABLE binlogs are now emitted.
- Does this need documentation: No.