### PR TITLE
[fix](binlog) Wrong judgment of anyEnable for add binlog (#48919)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
@@ -181,11 +181,7 @@ public class BinlogManager {
         if (tableIds != null) {
             for (long tableId : tableIds) {
                 boolean tableBinlogEnable = binlogConfigCache.isEnableTable(dbId, tableId);
-                if (tableIds.size() > 1) {
-                    anyEnable = anyEnable || tableBinlogEnable;
-                } else {
-                    anyEnable = tableBinlogEnable;
-                }
+                anyEnable = anyEnable || tableBinlogEnable;
                 if (anyEnable) {
                     break;
                 }

--- a/fe/fe-core/src/test/java/org/apache/doris/binlog/BinlogManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/binlog/BinlogManagerTest.java
@@ -162,8 +162,14 @@ public class BinlogManagerTest {
         Assert.assertTrue(dbBinlogMap.containsKey(dbBaseId));
         List<TBinlog> binlogs = Lists.newArrayList();
         dbBinlogMap.get(dbBaseId).getAllBinlogs(binlogs);
-        Assert.assertEquals(2, binlogs.size());
-        Assert.assertEquals(commitSeq, binlogs.get(1).getCommitSeq());
+        boolean found = false;
+        for (TBinlog binlog : binlogs) {
+            if (binlog.getType() == TBinlogType.UPSERT && binlog.getCommitSeq() == commitSeq) {
+                found = true;
+                break;
+            }
+        }
+        Assert.assertTrue(found);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/binlog/BinlogManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/binlog/BinlogManagerTest.java
@@ -63,6 +63,7 @@ public class BinlogManagerTest {
     private long ttl = 3;
 
     private boolean enableDbBinlog = false;
+    private boolean enableTableBinlog = true;
 
     @BeforeClass
     public static void beforeClass() {
@@ -72,6 +73,8 @@ public class BinlogManagerTest {
     @Before
     public void setUp() {
         Assert.assertTrue(tableNumPerDb < 100);
+        enableDbBinlog = false;
+        enableTableBinlog = true;
         frameWork = Maps.newHashMap();
         for (int dbOff = 1; dbOff <= dbNum; ++dbOff) {
             long dbId = dbOff * dbBaseId;
@@ -95,7 +98,7 @@ public class BinlogManagerTest {
 
             @Mock
             public boolean isEnableTable(long dbId, long tableId) {
-                return true;
+                return enableTableBinlog;
             }
 
             @Mock
@@ -136,6 +139,31 @@ public class BinlogManagerTest {
                 return new BinlogConfig();
             }
         };
+    }
+
+    @Test
+    public void testAddSingleTableBinlogWhenOnlyDbBinlogEnabled() throws NoSuchMethodException,
+            InvocationTargetException, IllegalAccessException, NoSuchFieldException {
+        enableDbBinlog = true;
+        enableTableBinlog = false;
+
+        Method addBinlog = BinlogManager.class.getDeclaredMethod("addBinlog", long.class, List.class,
+                long.class, long.class, TBinlogType.class, String.class, boolean.class, Object.class);
+        addBinlog.setAccessible(true);
+        Field dbBinlogMapField = BinlogManager.class.getDeclaredField("dbBinlogMap");
+        dbBinlogMapField.setAccessible(true);
+
+        BinlogManager manager = new BinlogManager();
+        long commitSeq = 1L;
+        addBinlog.invoke(manager, dbBaseId, Lists.newArrayList(tableBaseId), commitSeq, timeNow,
+                TBinlogType.UPSERT, "", false, null);
+
+        Map<Long, DBBinlog> dbBinlogMap = (Map<Long, DBBinlog>) dbBinlogMapField.get(manager);
+        Assert.assertTrue(dbBinlogMap.containsKey(dbBaseId));
+        List<TBinlog> binlogs = Lists.newArrayList();
+        dbBinlogMap.get(dbBaseId).getAllBinlogs(binlogs);
+        Assert.assertEquals(2, binlogs.size());
+        Assert.assertEquals(commitSeq, binlogs.get(1).getCommitSeq());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #48919

Problem Summary:

For a binlog event with exactly one table ID, 3.1 assigns `anyEnable = tableBinlogEnable` and overwrites the prior database-level result. Thus a database with `binlog.enable=true` can incorrectly skip the event when the table cache returns false, including `swap=false REPLACE TABLE` after a cold cache.

This is a clean cherry-pick of upstream #48919. It retains the database result and combines table results with OR.

### Release note

Fixes eligible single-table binlog events being skipped when database-level binlog is enabled.

### Check List (For Author)

- Test: No need to test. This is a clean cherry-pick; `git diff --check` passed. The worktree lacks `thirdparty/installed/bin/protoc`, so FE tests could not run.
- Behavior changed: Yes. Database-level enabled single-table events are emitted as configured.
- Does this need documentation: No.